### PR TITLE
Add EAS Build CI/CD workflow for mobile app

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,47 @@
+name: EAS Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: EAS Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Set up Expo and EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build preview (pull request)
+        if: github.event_name == 'pull_request'
+        working-directory: apps/mobile
+        run: eas build --profile preview --platform all --non-interactive
+
+      - name: Build development (main branch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: apps/mobile
+        run: eas build --profile development --platform all --non-interactive

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "channel": "development",
+      "ios": {
+        "buildConfiguration": "Debug"
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "channel": "preview",
+      "android": {
+        "buildType": "apk"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Expo Application Services (EAS) Build integration to the project, enabling automated building and distribution of the mobile app through GitHub Actions.

## Key Changes
- **GitHub Actions Workflow** (`.github/workflows/eas-build.yml`): Added a new CI/CD pipeline that:
  - Triggers on pushes to `main` and pull requests against `main`
  - Sets up Node.js 20 with pnpm package manager
  - Installs Expo and EAS CLI tools
  - Builds preview APKs for pull requests
  - Builds development APKs for pushes to main branch
  - Supports both iOS and Android platforms

- **EAS Configuration** (`apps/mobile/eas.json`): Added build profiles for:
  - **Development**: Uses development client with Debug configuration for iOS and APK for Android
  - **Preview**: Internal distribution APK builds for testing
  - Both profiles use internal distribution channel for team testing

## Implementation Details
- The workflow uses `expo/expo-github-action@v8` for seamless Expo tooling integration
- Requires `EXPO_TOKEN` secret to be configured in GitHub repository settings
- Development builds use the development client for faster iteration
- Preview builds are optimized for internal testing and QA
- All builds run non-interactively to support CI/CD automation

https://claude.ai/code/session_01DEPW7va1P3vAZvT6nsJJR5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now triggers remote EAS builds using a repository secret, which can impact build costs/throughput and requires correct secret/scoping; runtime app behavior is unchanged.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/eas-build.yml`) that installs dependencies and runs `eas build` for `apps/mobile` on pull requests (preview profile) and on pushes to `main` (development profile), authenticated via `EXPO_TOKEN`.
> 
> Introduces `apps/mobile/eas.json` defining `preview` and `development` build profiles (internal distribution, Android APK builds, and a debug iOS dev-client configuration for development).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f0b60c2e01d1c1674b21a1bf5c48b15f802c043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->