### PR TITLE
Implement YouTube content sync with Inngest background jobs

### DIFF
--- a/apps/web/app/api/connect/youtube/callback/route.ts
+++ b/apps/web/app/api/connect/youtube/callback/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { encryptToken } from "@meridian/api";
+import { inngest } from "@meridian/inngest";
 import { createServerClient } from "@/lib/supabase/server";
 
 /**
@@ -145,7 +146,7 @@ export async function GET(request: NextRequest) {
     Date.now() + tokens.expires_in * 1000
   ).toISOString();
 
-  const { error: upsertErr } = await supabase
+  const { data: platformData, error: upsertErr } = await supabase
     .from("connected_platforms")
     .upsert(
       {
@@ -160,22 +161,29 @@ export async function GET(request: NextRequest) {
         status: "active",
       },
       { onConflict: "creator_id,platform" }
-    );
+    )
+    .select("id")
+    .single();
 
-  if (upsertErr) {
+  if (upsertErr || !platformData) {
     console.error(
       "[youtube/callback] connected_platforms upsert failed:",
-      upsertErr.message
+      upsertErr?.message
     );
     return NextResponse.redirect(`${siteUrl}/connect?error=save_failed`);
   }
 
-  // ── 7. Clear state cookie and redirect to success ────────────────────────
-  // TODO: Fire platform/connected Inngest event once Inngest is wired up:
-  //   await inngest.send({ name: "platform/connected", data: {
-  //     creator_id: creator.id, platform: "youtube", connected_platform_id: ...
-  //   }});
+  // ── 7. Fire platform/connected event to kick off content sync ────────────
+  await inngest.send({
+    name: "platform/connected",
+    data: {
+      creator_id: creator.id,
+      platform: "youtube",
+      connected_platform_id: platformData.id,
+    },
+  });
 
+  // ── 8. Clear state cookie and redirect to success ────────────────────────
   const response = NextResponse.redirect(`${siteUrl}/connect?success=youtube`);
   response.cookies.delete("youtube_oauth_state");
   return response;

--- a/apps/web/app/api/inngest/route.ts
+++ b/apps/web/app/api/inngest/route.ts
@@ -1,0 +1,24 @@
+import { serve } from "inngest/next";
+import {
+  inngest,
+  syncYoutubeMetadata,
+  handlePlatformConnected,
+} from "@meridian/inngest";
+
+/**
+ * Inngest serve endpoint for the Meridian web app.
+ *
+ * Registers all background function handlers so that Inngest can invoke them
+ * via this route. The SDK handles GET (introspection), POST (function execution),
+ * and PUT (registration sync) automatically.
+ *
+ * Required env vars (production):
+ *   INNGEST_SIGNING_KEY  – verifies requests are from Inngest servers
+ *   INNGEST_EVENT_KEY    – used when sending events from the app
+ *
+ * In development with `inngest dev`, no signing key is needed.
+ */
+export const { GET, POST, PUT } = serve({
+  client: inngest,
+  functions: [syncYoutubeMetadata, handlePlatformConnected],
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@meridian/types": "workspace:*",
     "@meridian/ui": "workspace:*",
     "@supabase/ssr": "^0.8.0",
+    "inngest": "^3.52.3",
     "next": "15.3.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -11,9 +11,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@meridian/types": "workspace:*"
+    "@meridian/api": "workspace:*",
+    "@meridian/types": "workspace:*",
+    "@supabase/supabase-js": "^2.0.0"
   },
   "devDependencies": {
+    "inngest": "^3.0.0",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {

--- a/packages/inngest/src/client.ts
+++ b/packages/inngest/src/client.ts
@@ -1,9 +1,15 @@
-/**
- * Inngest client — wired up in E02 once the Inngest SDK is installed.
- *
- * When ready, replace this stub with:
- *   import { Inngest } from "inngest";
- *   export const inngest = new Inngest({ id: INNGEST_APP_ID });
- */
+import { EventSchemas, Inngest } from "inngest";
+import type { MeridianEvents } from "./events";
 
 export const INNGEST_APP_ID = "meridian" as const;
+
+/**
+ * Typed Inngest client shared across all Meridian background functions.
+ *
+ * Event schemas are registered via EventSchemas.fromRecord() so that every
+ * send() and createFunction() call is fully type-safe.
+ */
+export const inngest = new Inngest({
+  id: INNGEST_APP_ID,
+  schemas: new EventSchemas().fromRecord<MeridianEvents>(),
+});

--- a/packages/inngest/src/functions/platform-connected.ts
+++ b/packages/inngest/src/functions/platform-connected.ts
@@ -1,0 +1,28 @@
+import { inngest } from "../client";
+
+/**
+ * Handles the platform/connected event.
+ *
+ * For YouTube connections, immediately enqueues a full content sync so that
+ * content_items are populated as soon as the creator connects their channel.
+ */
+export const handlePlatformConnected = inngest.createFunction(
+  {
+    id: "handle-platform-connected",
+    name: "Handle Platform Connected",
+    retries: 2,
+  },
+  { event: "platform/connected" },
+  async ({ event, step }) => {
+    const { creator_id, platform, connected_platform_id } = event.data;
+
+    if (platform === "youtube") {
+      await step.sendEvent("request-youtube-sync", {
+        name: "content/sync.requested",
+        data: { creator_id, connected_platform_id, platform },
+      });
+    }
+
+    return { creator_id, platform };
+  }
+);

--- a/packages/inngest/src/functions/youtube-sync.ts
+++ b/packages/inngest/src/functions/youtube-sync.ts
@@ -1,0 +1,253 @@
+import { createClient } from "@supabase/supabase-js";
+import { decryptToken } from "@meridian/api";
+import { inngest } from "../client";
+
+// ─── YouTube API response types ───────────────────────────────────────────────
+
+interface ChannelsResponse {
+  items?: Array<{
+    contentDetails: {
+      relatedPlaylists: {
+        uploads: string;
+      };
+    };
+  }>;
+}
+
+interface PlaylistItemsResponse {
+  nextPageToken?: string;
+  items: Array<{
+    contentDetails: { videoId: string };
+  }>;
+}
+
+interface VideosListResponse {
+  items: Array<{
+    id: string;
+    snippet: {
+      title: string;
+      publishedAt: string;
+      thumbnails: {
+        high?: { url: string };
+        medium?: { url: string };
+        default?: { url: string };
+      };
+    };
+    contentDetails: {
+      duration: string; // ISO 8601 e.g. "PT4M13S"
+    };
+  }>;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Converts an ISO 8601 duration string (e.g. "PT4M13S") to total seconds.
+ * Returns 0 for unrecognised formats.
+ */
+function parseDuration(iso: string): number {
+  const match = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!match) return 0;
+  return (
+    parseInt(match[1] ?? "0", 10) * 3600 +
+    parseInt(match[2] ?? "0", 10) * 60 +
+    parseInt(match[3] ?? "0", 10)
+  );
+}
+
+/** Returns the best available thumbnail URL from a YouTube thumbnails object. */
+function pickThumbnail(
+  thumbnails: VideosListResponse["items"][0]["snippet"]["thumbnails"]
+): string | null {
+  return (
+    thumbnails.high?.url ?? thumbnails.medium?.url ?? thumbnails.default?.url ?? null
+  );
+}
+
+function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+// ─── Inngest function ─────────────────────────────────────────────────────────
+
+/**
+ * Syncs all YouTube video metadata for a connected channel into content_items.
+ *
+ * Triggered by: content/sync.requested  (platform === "youtube")
+ *
+ * Steps:
+ *  1. fetch-platform     – Load connected_platforms row; decrypt access token.
+ *  2. fetch-uploads-playlist – Get the channel's uploads playlist ID.
+ *  3. sync-page-<token>  – One step per playlist page (50 videos each).
+ *                          Each step fetches full video details and upserts
+ *                          rows into content_items.
+ */
+export const syncYoutubeMetadata = inngest.createFunction(
+  {
+    id: "sync-youtube-metadata",
+    name: "Sync YouTube Video Metadata",
+    retries: 3,
+  },
+  { event: "content/sync.requested" },
+  async ({ event, step }) => {
+    const { creator_id, connected_platform_id, platform } = event.data;
+
+    if (platform !== "youtube") {
+      return { skipped: true, reason: "platform is not youtube" };
+    }
+
+    // ── Step 1: load the connected platform row ──────────────────────────────
+    const platformRow = await step.run("fetch-platform", async () => {
+      const supabase = getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from("connected_platforms")
+        .select("id, access_token_enc, platform_user_id")
+        .eq("id", connected_platform_id)
+        .single();
+
+      if (error || !data) {
+        throw new Error(
+          `Connected platform not found (id=${connected_platform_id}): ${error?.message}`
+        );
+      }
+      return data as {
+        id: string;
+        access_token_enc: string;
+        platform_user_id: string;
+      };
+    });
+
+    // ── Step 2: resolve the channel's uploads playlist ID ───────────────────
+    const uploadsPlaylistId = await step.run(
+      "fetch-uploads-playlist",
+      async () => {
+        const accessToken = decryptToken(platformRow.access_token_enc);
+        const url = new URL(
+          "https://www.googleapis.com/youtube/v3/channels"
+        );
+        url.searchParams.set("part", "contentDetails");
+        url.searchParams.set("id", platformRow.platform_user_id);
+
+        const res = await fetch(url.toString(), {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!res.ok) {
+          throw new Error(
+            `YouTube channels API failed (${res.status}): ${await res.text()}`
+          );
+        }
+
+        const data: ChannelsResponse = await res.json();
+        const uploads =
+          data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads;
+
+        if (!uploads) {
+          throw new Error(
+            `No uploads playlist found for channel ${platformRow.platform_user_id}`
+          );
+        }
+        return uploads;
+      }
+    );
+
+    // ── Step 3+: paginate through playlist pages and upsert videos ───────────
+    let pageToken: string | undefined;
+    let totalUpserted = 0;
+
+    do {
+      const stepId = `sync-page-${pageToken ?? "initial"}`;
+
+      const result = await step.run(stepId, async () => {
+        const accessToken = decryptToken(platformRow.access_token_enc);
+        const supabase = getSupabaseAdmin();
+
+        // 3a. List video IDs from the uploads playlist
+        const playlistUrl = new URL(
+          "https://www.googleapis.com/youtube/v3/playlistItems"
+        );
+        playlistUrl.searchParams.set("part", "contentDetails");
+        playlistUrl.searchParams.set("playlistId", uploadsPlaylistId);
+        playlistUrl.searchParams.set("maxResults", "50");
+        if (pageToken) {
+          playlistUrl.searchParams.set("pageToken", pageToken);
+        }
+
+        const playlistRes = await fetch(playlistUrl.toString(), {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!playlistRes.ok) {
+          throw new Error(
+            `YouTube playlistItems API failed (${playlistRes.status}): ${await playlistRes.text()}`
+          );
+        }
+
+        const playlistData: PlaylistItemsResponse = await playlistRes.json();
+        const videoIds = playlistData.items.map(
+          (item) => item.contentDetails.videoId
+        );
+
+        if (videoIds.length === 0) {
+          return { nextPageToken: undefined, upserted: 0 };
+        }
+
+        // 3b. Fetch full metadata for this batch of video IDs
+        const videosUrl = new URL(
+          "https://www.googleapis.com/youtube/v3/videos"
+        );
+        videosUrl.searchParams.set("part", "snippet,contentDetails");
+        videosUrl.searchParams.set("id", videoIds.join(","));
+
+        const videosRes = await fetch(videosUrl.toString(), {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        if (!videosRes.ok) {
+          throw new Error(
+            `YouTube videos API failed (${videosRes.status}): ${await videosRes.text()}`
+          );
+        }
+
+        const videosData: VideosListResponse = await videosRes.json();
+
+        // 3c. Upsert rows into content_items
+        const rows = videosData.items.map((video) => ({
+          creator_id,
+          platform_id: connected_platform_id,
+          platform: "youtube" as const,
+          external_id: video.id,
+          title: video.snippet.title,
+          published_at: video.snippet.publishedAt,
+          thumbnail_url: pickThumbnail(video.snippet.thumbnails),
+          duration_seconds: parseDuration(video.contentDetails.duration),
+          raw_data: video,
+        }));
+
+        const { error, count } = await supabase
+          .from("content_items")
+          .upsert(rows, {
+            onConflict: "creator_id,platform,external_id",
+            count: "exact",
+          });
+
+        if (error) {
+          throw new Error(`content_items upsert failed: ${error.message}`);
+        }
+
+        return {
+          nextPageToken: playlistData.nextPageToken,
+          upserted: count ?? rows.length,
+        };
+      });
+
+      pageToken = result.nextPageToken;
+      totalUpserted += result.upserted;
+    } while (pageToken);
+
+    return { creator_id, connected_platform_id, totalUpserted };
+  }
+);

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -1,9 +1,13 @@
 /**
  * @meridian/inngest — Shared Inngest configuration
  *
- * Exports the Inngest app ID, typed event schemas, and (in E02) the
- * Inngest client instance used by all background job handlers.
+ * Exports the Inngest client, typed event schemas, and all background
+ * function handlers used by the Meridian platform.
  */
 
-export { INNGEST_APP_ID } from "./client";
+export { INNGEST_APP_ID, inngest } from "./client";
 export type { MeridianEvents } from "./events";
+
+// ─── Background function handlers ────────────────────────────────────────────
+export { syncYoutubeMetadata } from "./functions/youtube-sync";
+export { handlePlatformConnected } from "./functions/platform-connected";

--- a/packages/inngest/tsconfig.json
+++ b/packages/inngest/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "paths": {
+      "@meridian/api": ["../api/src/index.ts"],
       "@meridian/types": ["../types/src/index.ts"]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.97.0)
+      inngest:
+        specifier: ^3.52.3
+        version: 3.52.3(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(next@15.3.9(@opentelemetry/api@1.9.0)(react-dom@19.0.3(react@19.0.3))(react@19.0.3))(typescript@5.9.3)(zod@4.3.6)
       next:
         specifier: 15.3.9
         version: 15.3.9(@opentelemetry/api@1.9.0)(react-dom@19.0.3(react@19.0.3))(react@19.0.3)
@@ -163,13 +166,19 @@ importers:
 
   packages/inngest:
     dependencies:
+      '@meridian/api':
+        specifier: workspace:*
+        version: link:../api
       '@meridian/types':
         specifier: workspace:*
         version: link:../types
+      '@supabase/supabase-js':
+        specifier: ^2.0.0
+        version: 2.97.0
+    devDependencies:
       inngest:
         specifier: ^3.0.0
         version: 3.52.3(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(next@15.3.9(@opentelemetry/api@1.9.0)(react-dom@19.0.3(react@19.0.3))(react@19.0.3))(typescript@5.9.3)(zod@4.3.6)
-    devDependencies:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3

--- a/supabase/migrations/20260225000001_add_content_items_metadata.sql
+++ b/supabase/migrations/20260225000001_add_content_items_metadata.sql
@@ -1,0 +1,11 @@
+-- =============================================================
+-- Meridian – Add metadata columns to content_items
+-- Migration: 20260225000001_add_content_items_metadata.sql
+--
+-- Adds thumbnail_url and duration_seconds to content_items so
+-- the YouTube sync job can populate these fields directly.
+-- =============================================================
+
+alter table content_items
+  add column if not exists thumbnail_url    text,
+  add column if not exists duration_seconds integer;


### PR DESCRIPTION
## Summary
This PR implements a complete YouTube content synchronization pipeline using Inngest background jobs. When a creator connects their YouTube channel, the system automatically fetches all video metadata and populates the `content_items` table.

## Key Changes

- **YouTube Sync Function** (`packages/inngest/src/functions/youtube-sync.ts`)
  - New Inngest function that syncs all YouTube video metadata for a connected channel
  - Fetches channel uploads playlist, then paginates through all videos (50 per page)
  - Extracts video title, publish date, thumbnail, and duration (ISO 8601 → seconds)
  - Upserts video data into `content_items` table with conflict resolution
  - Implements helper functions for duration parsing and thumbnail selection

- **Platform Connected Handler** (`packages/inngest/src/functions/platform-connected.ts`)
  - New Inngest function triggered when a platform connection is established
  - For YouTube connections, immediately enqueues a content sync request
  - Enables automatic population of content when creators connect their channels

- **YouTube OAuth Callback Integration** (`apps/web/app/api/connect/youtube/callback/route.ts`)
  - Updated to fire `platform/connected` event after successful platform upsert
  - Now retrieves the `connected_platform_id` from the upsert response
  - Passes platform connection details to Inngest for async processing

- **Inngest Serve Endpoint** (`apps/web/app/api/inngest/route.ts`)
  - New API route that registers all Inngest function handlers
  - Handles GET (introspection), POST (execution), and PUT (sync) from Inngest servers
  - Enables the web app to receive and execute background jobs

- **Inngest Client Setup** (`packages/inngest/src/client.ts`)
  - Implemented typed Inngest client with event schema validation
  - Uses `EventSchemas.fromRecord()` for full type safety on all event operations

- **Database Migration** (`supabase/migrations/20260225000001_add_content_items_metadata.sql`)
  - Adds `thumbnail_url` and `duration_seconds` columns to `content_items` table
  - Enables storage of YouTube video metadata

- **Package Updates**
  - Added `inngest` dependency to both `@meridian/inngest` and `apps/web`
  - Added `@supabase/supabase-js` to `@meridian/inngest` for database operations
  - Updated exports in `packages/inngest/src/index.ts` to include new functions

## Implementation Details

- The sync function uses Inngest's step-based architecture to create one step per playlist page, enabling efficient pagination and error recovery
- Video duration is parsed from ISO 8601 format (e.g., "PT4M13S") to total seconds
- Thumbnail selection prioritizes high → medium → default quality
- Upsert operations use composite key conflict resolution on `(creator_id, platform, external_id)`
- All YouTube API calls include proper error handling and token decryption

https://claude.ai/code/session_01KQqmrgiANZTtTEtAiCtAvh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new background execution paths that call external YouTube APIs and write to `content_items` via a service-role key, so failures or misconfiguration could cause sync errors or unexpected data writes.
> 
> **Overview**
> Adds an Inngest-backed YouTube sync pipeline that automatically populates `content_items` after a creator connects their channel.
> 
> The YouTube OAuth callback now selects the upserted `connected_platforms.id` and immediately sends a `platform/connected` event; the web app also adds an `/api/inngest` serve route to register background handlers. The new Inngest functions translate `platform/connected` into `content/sync.requested` and then fetch/paginate YouTube uploads, upserting video metadata (including new `thumbnail_url` and `duration_seconds` columns) into `content_items` using a Supabase service-role client.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a8514f06ff49268b53b4e60547680c7632ba880. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->