### PR TITLE
Configure EAS project and add Expo owner to app.json

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "Meridian",
     "slug": "meridian",
+    "owner": "thatsmyboye",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
@@ -31,6 +32,11 @@
     "plugins": ["expo-router"],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "eas": {
+        "projectId": "1916c841-542c-4ef5-b3c1-8de20525be07"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Updated the Expo configuration in `app.json` to include EAS (Expo Application Services) project settings and specify the Expo account owner.

## Key Changes
- Added `"owner": "thatsmyboye"` to identify the Expo account owner for the Meridian project
- Added EAS configuration with `projectId: "1916c841-542c-4ef5-b3c1-8de20525be07"` under a new `"extra"` section to enable EAS build and deployment services

## Details
These changes enable the mobile app to use Expo's managed services for building and deploying the application. The owner field associates the project with the correct Expo account, while the EAS project ID links the app to its corresponding EAS project for CI/CD workflows.

https://claude.ai/code/session_01SgxrxvH4DPGiHc2HFeXuxB