### PR TITLE
Add Beehiiv newsletter platform support with analytics

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -24,3 +24,7 @@ META_APP_SECRET=<your-meta-app-secret>
 # AES-256-GCM key for encrypting OAuth tokens at rest (64 hex chars = 32 bytes)
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 TOKEN_ENCRYPTION_KEY=<64-hex-char-key>
+
+# Beehiiv – no server-side credentials required.
+# Creators supply their own API key and publication ID via the /connect/beehiiv form.
+# The API key is validated against https://api.beehiiv.com/v2 and stored encrypted.

--- a/apps/web/app/api/connect/beehiiv/route.ts
+++ b/apps/web/app/api/connect/beehiiv/route.ts
@@ -1,0 +1,155 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { encryptToken } from "@meridian/api";
+import { inngest } from "@meridian/inngest";
+import { createServerClient } from "@/lib/supabase/server";
+
+/**
+ * POST /api/connect/beehiiv
+ *
+ * Validates a creator's Beehiiv API key + publication ID, then persists the
+ * encrypted credentials in connected_platforms and kicks off an initial
+ * content sync.
+ *
+ * Unlike OAuth-based platforms, Beehiiv uses long-lived API keys that do not
+ * expire and require no refresh flow. The key is encrypted at rest using the
+ * same AES-256-GCM scheme as OAuth tokens.
+ *
+ * Steps:
+ *  1. Parse and validate form fields.
+ *  2. Verify the creator is authenticated.
+ *  3. Validate the API key + publication ID against Beehiiv's API.
+ *  4. Encrypt the API key.
+ *  5. Upsert a row in connected_platforms.
+ *  6. Fire platform/connected to trigger an immediate content sync.
+ *  7. Redirect to /connect?success=beehiiv.
+ */
+
+const BEEHIIV_API_BASE = "https://api.beehiiv.com/v2";
+
+interface BeehiivPublicationResponse {
+  data: {
+    id: string;
+    name: string;
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ?? new URL(request.url).origin;
+
+  // ── 1. Parse form body ────────────────────────────────────────────────────
+  const formData = await request.formData();
+  const apiKey = (formData.get("api_key") as string | null)?.trim();
+  const publicationId = (
+    formData.get("publication_id") as string | null
+  )?.trim();
+
+  if (!apiKey || !publicationId) {
+    return NextResponse.redirect(
+      `${siteUrl}/connect/beehiiv?error=missing_params`
+    );
+  }
+
+  // ── 2. Verify authenticated creator ──────────────────────────────────────
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.redirect(
+      `${siteUrl}/connect/beehiiv?error=unauthenticated`
+    );
+  }
+
+  // ── 3. Validate credentials against Beehiiv API ──────────────────────────
+  // Fetching the publication details proves both the API key and publication
+  // ID are correct. If either is wrong, the API returns a 401 or 404.
+  const validationRes = await fetch(
+    `${BEEHIIV_API_BASE}/publications/${encodeURIComponent(publicationId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!validationRes.ok) {
+    console.error(
+      "[beehiiv/connect] Credential validation failed:",
+      validationRes.status,
+      await validationRes.text()
+    );
+    return NextResponse.redirect(
+      `${siteUrl}/connect/beehiiv?error=invalid_credentials`
+    );
+  }
+
+  const publication: BeehiivPublicationResponse = await validationRes.json();
+  const publicationName = publication.data.name;
+
+  // ── 4. Look up the creator row ────────────────────────────────────────────
+  const { data: creator, error: creatorErr } = await supabase
+    .from("creators")
+    .select("id")
+    .eq("auth_user_id", user.id)
+    .single();
+
+  if (creatorErr || !creator) {
+    console.error(
+      "[beehiiv/connect] Creator lookup failed:",
+      creatorErr?.message
+    );
+    return NextResponse.redirect(
+      `${siteUrl}/connect/beehiiv?error=creator_not_found`
+    );
+  }
+
+  // ── 5. Encrypt the API key and upsert connected_platforms ─────────────────
+  // Beehiiv API keys are long-lived and do not expire, so token_expires_at
+  // and refresh_token_enc are left as null.
+  const accessTokenEnc = encryptToken(apiKey);
+
+  const { data: platformData, error: upsertErr } = await supabase
+    .from("connected_platforms")
+    .upsert(
+      {
+        creator_id: creator.id,
+        platform: "beehiiv",
+        platform_user_id: publicationId,
+        platform_username: publicationName,
+        access_token_enc: accessTokenEnc,
+        refresh_token_enc: null,
+        token_expires_at: null,
+        scopes: [],
+        status: "active",
+      },
+      { onConflict: "creator_id,platform" }
+    )
+    .select("id")
+    .single();
+
+  if (upsertErr || !platformData) {
+    console.error(
+      "[beehiiv/connect] connected_platforms upsert failed:",
+      upsertErr?.message
+    );
+    return NextResponse.redirect(
+      `${siteUrl}/connect/beehiiv?error=save_failed`
+    );
+  }
+
+  // ── 6. Fire platform/connected to kick off an initial content sync ─────────
+  await inngest.send({
+    name: "platform/connected",
+    data: {
+      creator_id: creator.id,
+      platform: "beehiiv",
+      connected_platform_id: platformData.id,
+    },
+  });
+
+  // ── 7. Redirect to success ────────────────────────────────────────────────
+  return NextResponse.redirect(`${siteUrl}/connect?success=beehiiv`);
+}

--- a/apps/web/app/api/inngest/route.ts
+++ b/apps/web/app/api/inngest/route.ts
@@ -8,6 +8,9 @@ import {
   syncInstagramMedia,
   instagramAnalyticsCron,
   fetchInstagramAnalyticsSnapshot,
+  syncBeehiivPosts,
+  beehiivAnalyticsCron,
+  fetchBeehiivAnalyticsSnapshot,
 } from "@meridian/inngest";
 
 /**
@@ -33,5 +36,8 @@ export const { GET, POST, PUT } = serve({
     syncInstagramMedia,
     instagramAnalyticsCron,
     fetchInstagramAnalyticsSnapshot,
+    syncBeehiivPosts,
+    beehiivAnalyticsCron,
+    fetchBeehiivAnalyticsSnapshot,
   ],
 });

--- a/apps/web/app/connect/beehiiv/page.tsx
+++ b/apps/web/app/connect/beehiiv/page.tsx
@@ -1,0 +1,161 @@
+/**
+ * /connect/beehiiv – Beehiiv API key connection page
+ *
+ * Unlike OAuth-based platforms, Beehiiv uses API key authentication.
+ * Creators enter their API key and publication ID; we validate the
+ * credentials against the Beehiiv API before saving them.
+ */
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing_params: "Please provide both an API key and a publication ID.",
+  invalid_credentials:
+    "Could not verify your Beehiiv credentials. Check that your API key and publication ID are correct.",
+  creator_not_found:
+    "Your creator profile was not found. Please sign out and back in.",
+  save_failed:
+    "Credentials validated but could not be saved. Please try again.",
+  unauthenticated: "You must be signed in to connect a platform.",
+};
+
+interface BeehiivConnectPageProps {
+  searchParams: Promise<{ error?: string }>;
+}
+
+export default async function BeehiivConnectPage({
+  searchParams,
+}: BeehiivConnectPageProps) {
+  const { error } = await searchParams;
+
+  const errorMessage = error
+    ? (ERROR_MESSAGES[error] ??
+      "An unexpected error occurred. Please try again.")
+    : null;
+
+  return (
+    <main
+      style={{
+        maxWidth: 480,
+        margin: "64px auto",
+        padding: "0 24px",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <a
+        href="/connect"
+        style={{
+          display: "inline-block",
+          marginBottom: 24,
+          fontSize: 14,
+          color: "#6b7280",
+          textDecoration: "none",
+        }}
+      >
+        ← Back to platforms
+      </a>
+
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>
+        Connect Beehiiv
+      </h1>
+      <p style={{ color: "#6b7280", marginBottom: 32 }}>
+        Enter your Beehiiv API key and publication ID to import your newsletter
+        posts and track open rates and clicks in Meridian.
+      </p>
+
+      {errorMessage && (
+        <div
+          role="alert"
+          style={{
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            borderRadius: 8,
+            padding: "12px 16px",
+            marginBottom: 24,
+            color: "#991b1b",
+            fontSize: 14,
+          }}
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      <form
+        method="POST"
+        action="/api/connect/beehiiv"
+        style={{ display: "flex", flexDirection: "column", gap: 20 }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <label
+            htmlFor="api_key"
+            style={{ fontWeight: 600, fontSize: 14 }}
+          >
+            API Key
+          </label>
+          <input
+            id="api_key"
+            name="api_key"
+            type="password"
+            required
+            placeholder="bh_api_••••••••••••••••••••••••••••"
+            autoComplete="off"
+            style={{
+              padding: "10px 12px",
+              border: "1px solid #d1d5db",
+              borderRadius: 6,
+              fontSize: 14,
+              fontFamily: "monospace",
+              outline: "none",
+            }}
+          />
+          <p style={{ fontSize: 12, color: "#9ca3af", margin: 0 }}>
+            Find your API key in Beehiiv → Settings → API.
+          </p>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <label
+            htmlFor="publication_id"
+            style={{ fontWeight: 600, fontSize: 14 }}
+          >
+            Publication ID
+          </label>
+          <input
+            id="publication_id"
+            name="publication_id"
+            type="text"
+            required
+            placeholder="pub_••••••••••••••••••••••••••••••••"
+            autoComplete="off"
+            style={{
+              padding: "10px 12px",
+              border: "1px solid #d1d5db",
+              borderRadius: 6,
+              fontSize: 14,
+              fontFamily: "monospace",
+              outline: "none",
+            }}
+          />
+          <p style={{ fontSize: 12, color: "#9ca3af", margin: 0 }}>
+            Find your publication ID in Beehiiv → Settings → Publication details.
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          style={{
+            background: "#f97316",
+            color: "#fff",
+            padding: "10px 20px",
+            borderRadius: 6,
+            border: "none",
+            fontWeight: 600,
+            fontSize: 14,
+            cursor: "pointer",
+            alignSelf: "flex-start",
+          }}
+        >
+          Connect newsletter
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/web/app/connect/page.tsx
+++ b/apps/web/app/connect/page.tsx
@@ -1,9 +1,9 @@
 /**
  * /connect – Platform connection page
  *
- * Lets creators connect their social accounts to Meridian via OAuth.
- * Supports YouTube and Instagram. Shows success/error feedback via query
- * params set by the OAuth callback routes.
+ * Lets creators connect their social accounts to Meridian via OAuth or API key.
+ * Supports YouTube, Instagram, and Beehiiv. Shows success/error feedback via
+ * query params set by the connection routes.
  */
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -71,6 +71,22 @@ export default async function ConnectPage({ searchParams }: ConnectPageProps) {
           }}
         >
           Instagram connected successfully. Your posts will be imported shortly.
+        </div>
+      )}
+
+      {success === "beehiiv" && (
+        <div
+          role="status"
+          style={{
+            background: "#f0fdf4",
+            border: "1px solid #86efac",
+            borderRadius: 8,
+            padding: "12px 16px",
+            marginBottom: 24,
+            color: "#166534",
+          }}
+        >
+          Beehiiv connected successfully. Your newsletter posts will be imported shortly.
         </div>
       )}
 
@@ -165,6 +181,46 @@ export default async function ConnectPage({ searchParams }: ConnectPageProps) {
             }}
           >
             {success === "instagram" ? "Reconnect" : "Connect"}
+          </a>
+        </div>
+
+        {/* Beehiiv */}
+        <div
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 12,
+            padding: 20,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+          }}
+        >
+          <div>
+            <div style={{ fontWeight: 600, marginBottom: 4 }}>Beehiiv</div>
+            <div style={{ fontSize: 14, color: "#6b7280" }}>
+              Import newsletter posts and track open rates &amp; clicks
+            </div>
+            <div style={{ fontSize: 12, color: "#9ca3af", marginTop: 4 }}>
+              Requires a Beehiiv API key and publication ID
+            </div>
+          </div>
+
+          <a
+            href="/connect/beehiiv"
+            style={{
+              display: "inline-block",
+              background: "#f97316",
+              color: "#fff",
+              padding: "8px 18px",
+              borderRadius: 6,
+              textDecoration: "none",
+              fontWeight: 600,
+              fontSize: 14,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {success === "beehiiv" ? "Reconnect" : "Connect"}
           </a>
         </div>
       </div>

--- a/packages/inngest/src/functions/beehiiv-analytics-cron.ts
+++ b/packages/inngest/src/functions/beehiiv-analytics-cron.ts
@@ -1,0 +1,369 @@
+import { createClient } from "@supabase/supabase-js";
+import { decryptToken } from "@meridian/api";
+import { inngest } from "../client";
+
+// ─── Beehiiv API v2 response types ───────────────────────────────────────────
+
+interface BeehiivPostStats {
+  email: {
+    recipients: number;
+    open_rate: number;
+    click_rate: number;
+    unique_opened: number;
+    unique_clicked: number;
+  };
+  web: {
+    impressions: number;
+    unique_impressions: number;
+  };
+}
+
+interface BeehiivPostDetailResponse {
+  data: {
+    id: string;
+    stats: BeehiivPostStats;
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+/** Day marks (days after publication) at which we capture analytics snapshots. */
+const SNAPSHOT_DAY_MARKS = [1, 7, 30] as const;
+type DayMark = (typeof SNAPSHOT_DAY_MARKS)[number];
+
+// ─── Cron: daily scheduler ────────────────────────────────────────────────────
+
+/**
+ * Runs every day at 05:00 UTC (1 hour after the Instagram cron to spread load).
+ *
+ * For each lifecycle day mark (1, 7, 30) it finds Beehiiv newsletter posts
+ * whose publication date falls within a ±12-hour window of that mark and that
+ * have not yet received a snapshot for that mark. It then fans-out one
+ * `analytics/snapshot.requested` event per eligible post.
+ *
+ * Steps:
+ *  1. load-active-beehiiv-platforms  – All active Beehiiv connected platform IDs.
+ *  2. find-unsnapshotted-day-{N}     – Posts needing a snapshot at mark N.
+ *  3. dispatch-snapshot-events       – Fan-out events to the snapshot handler.
+ */
+export const beehiivAnalyticsCron = inngest.createFunction(
+  {
+    id: "beehiiv-analytics-cron",
+    name: "Beehiiv Analytics Daily Snapshot Cron",
+    retries: 1,
+  },
+  { cron: "0 5 * * *" },
+  async ({ step }) => {
+    // ── Step 1: resolve all active Beehiiv connected platform IDs ─────────────
+    const activePlatformIds = await step.run(
+      "load-active-beehiiv-platforms",
+      async () => {
+        const supabase = getSupabaseAdmin();
+        const { data, error } = await supabase
+          .from("connected_platforms")
+          .select("id")
+          .eq("platform", "beehiiv")
+          .eq("status", "active");
+
+        if (error) {
+          throw new Error(
+            `Failed to load active Beehiiv platforms: ${error.message}`
+          );
+        }
+
+        return (data ?? []).map((p) => p.id as string);
+      }
+    );
+
+    if (activePlatformIds.length === 0) {
+      return {
+        message: "No active Beehiiv platforms found — nothing to snapshot.",
+        snapshotsEnqueued: 0,
+      };
+    }
+
+    // ── Step 2: for each day mark, find posts that still need a snapshot ──────
+    const eventsToSend: Array<{
+      name: "analytics/snapshot.requested";
+      data: {
+        creator_id: string;
+        content_item_id: string;
+        platform: "beehiiv";
+        day_mark: DayMark;
+      };
+    }> = [];
+
+    for (const dayMark of SNAPSHOT_DAY_MARKS) {
+      const itemsNeedingSnapshot = await step.run(
+        `find-unsnapshotted-day-${dayMark}`,
+        async () => {
+          const supabase = getSupabaseAdmin();
+          const now = new Date();
+
+          // ±12-hour window around the exact day mark
+          const lower = new Date(
+            now.getTime() - (dayMark + 0.5) * 86_400_000
+          ).toISOString();
+          const upper = new Date(
+            now.getTime() - (dayMark - 0.5) * 86_400_000
+          ).toISOString();
+
+          const { data: candidates, error: candidateError } = await supabase
+            .from("content_items")
+            .select("id, creator_id")
+            .eq("platform", "beehiiv")
+            .in("platform_id", activePlatformIds)
+            .gte("published_at", lower)
+            .lte("published_at", upper);
+
+          if (candidateError) {
+            throw new Error(
+              `Failed to query content_items for day-${dayMark} mark: ${candidateError.message}`
+            );
+          }
+
+          if (!candidates?.length) return [];
+
+          // Filter out items that already have a snapshot for this day mark.
+          const { data: existing, error: existingError } = await supabase
+            .from("performance_snapshots")
+            .select("content_item_id")
+            .in(
+              "content_item_id",
+              candidates.map((c) => c.id)
+            )
+            .eq("day_mark", dayMark);
+
+          if (existingError) {
+            throw new Error(
+              `Failed to check existing snapshots for day-${dayMark}: ${existingError.message}`
+            );
+          }
+
+          const alreadySnapshotted = new Set(
+            (existing ?? []).map((e) => e.content_item_id as string)
+          );
+
+          return candidates
+            .filter((c) => !alreadySnapshotted.has(c.id as string))
+            .map((c) => ({
+              id: c.id as string,
+              creator_id: c.creator_id as string,
+            }));
+        }
+      );
+
+      for (const item of itemsNeedingSnapshot) {
+        eventsToSend.push({
+          name: "analytics/snapshot.requested",
+          data: {
+            creator_id: item.creator_id,
+            content_item_id: item.id,
+            platform: "beehiiv",
+            day_mark: dayMark,
+          },
+        });
+      }
+    }
+
+    // ── Step 3: fan-out one event per eligible content item ───────────────────
+    if (eventsToSend.length > 0) {
+      await step.sendEvent("dispatch-snapshot-events", eventsToSend);
+    }
+
+    return {
+      activePlatforms: activePlatformIds.length,
+      snapshotsEnqueued: eventsToSend.length,
+    };
+  }
+);
+
+// ─── Snapshot handler ─────────────────────────────────────────────────────────
+
+/**
+ * Fetches Beehiiv post stats for a single newsletter post and stores a
+ * `performance_snapshots` row.
+ *
+ * Triggered by: `analytics/snapshot.requested` (platform === "beehiiv")
+ *
+ * Beehiiv returns cumulative lifetime stats per post (recipients, opens,
+ * clicks, rates). We capture these at day 1, 7, and 30 after publication.
+ *
+ * Metric mapping:
+ *   views      ← stats.email.unique_opened   (email open count)
+ *   reach      ← stats.email.recipients      (total recipients)
+ *   clicks     ← stats.email.unique_clicked  (unique link clicks)
+ *   open_rate  ← stats.email.open_rate       (percentage, e.g. 42.5)
+ *   click_rate ← stats.email.click_rate      (percentage, e.g. 5.2)
+ *   impressions← stats.web.impressions       (web view count)
+ *
+ * Steps:
+ *  1. load-content-and-platform  – Load the content item + encrypted API key.
+ *  2. fetch-beehiiv-stats        – Call the Beehiiv posts API with expand=stats.
+ *  3. store-snapshot             – Insert a row into performance_snapshots.
+ */
+export const fetchBeehiivAnalyticsSnapshot = inngest.createFunction(
+  {
+    id: "fetch-beehiiv-analytics-snapshot",
+    name: "Fetch Beehiiv Analytics Snapshot",
+    retries: 3,
+    concurrency: { limit: 5 },
+  },
+  {
+    event: "analytics/snapshot.requested",
+    if: "event.data.platform == 'beehiiv'",
+  },
+  async ({ event, step }) => {
+    const { creator_id, content_item_id, platform, day_mark } = event.data;
+
+    if (platform !== "beehiiv") {
+      return { skipped: true, reason: "platform is not beehiiv" };
+    }
+
+    // ── Step 1: load content item + connected platform row ────────────────────
+    const { contentItem, platformRow } = await step.run(
+      "load-content-and-platform",
+      async () => {
+        const supabase = getSupabaseAdmin();
+
+        const { data: item, error: itemError } = await supabase
+          .from("content_items")
+          .select("id, external_id, platform_id")
+          .eq("id", content_item_id)
+          .single();
+
+        if (itemError || !item) {
+          throw new Error(
+            `Content item not found (id=${content_item_id}): ${itemError?.message}`
+          );
+        }
+        if (!item.external_id) {
+          throw new Error(
+            `Content item ${content_item_id} is missing external_id`
+          );
+        }
+        if (!item.platform_id) {
+          throw new Error(
+            `Content item ${content_item_id} has no linked connected_platform`
+          );
+        }
+
+        const { data: cp, error: cpError } = await supabase
+          .from("connected_platforms")
+          .select("id, access_token_enc, platform_user_id")
+          .eq("id", item.platform_id)
+          .single();
+
+        if (cpError || !cp) {
+          throw new Error(
+            `Connected platform not found (id=${item.platform_id}): ${cpError?.message}`
+          );
+        }
+
+        const apiKey = decryptToken(cp.access_token_enc as string);
+
+        return {
+          contentItem: item as {
+            id: string;
+            external_id: string;
+            platform_id: string;
+          },
+          platformRow: {
+            id: cp.id as string,
+            apiKey,
+            publicationId: cp.platform_user_id as string,
+          },
+        };
+      }
+    );
+
+    // ── Step 2: fetch post stats from Beehiiv API ─────────────────────────────
+    const metrics = await step.run("fetch-beehiiv-stats", async () => {
+      const url = new URL(
+        `https://api.beehiiv.com/v2/publications/${encodeURIComponent(
+          platformRow.publicationId
+        )}/posts/${encodeURIComponent(contentItem.external_id)}`
+      );
+      url.searchParams.set("expand[]", "stats");
+
+      const res = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${platformRow.apiKey}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error(
+          `Beehiiv post stats API failed (${res.status}): ${await res.text()}`
+        );
+      }
+
+      const body: BeehiivPostDetailResponse = await res.json();
+      const stats = body.data.stats;
+
+      return {
+        uniqueOpened: stats.email?.unique_opened ?? 0,
+        recipients: stats.email?.recipients ?? 0,
+        uniqueClicked: stats.email?.unique_clicked ?? 0,
+        openRate: stats.email?.open_rate ?? 0,
+        clickRate: stats.email?.click_rate ?? 0,
+        webImpressions: stats.web?.impressions ?? 0,
+        rawStats: stats,
+      };
+    });
+
+    // ── Step 3: persist the snapshot ──────────────────────────────────────────
+    await step.run("store-snapshot", async () => {
+      const supabase = getSupabaseAdmin();
+
+      const { error } = await supabase.from("performance_snapshots").insert({
+        content_item_id,
+        creator_id,
+        // Map newsletter metrics to the shared performance_snapshots schema.
+        views: metrics.uniqueOpened,
+        reach: metrics.recipients,
+        clicks: metrics.uniqueClicked,
+        open_rate: metrics.openRate,
+        click_rate: metrics.clickRate,
+        impressions: metrics.webImpressions,
+        // Newsletters do not have likes, comments, shares, or saves.
+        likes: 0,
+        comments: 0,
+        shares: 0,
+        saves: 0,
+        day_mark: day_mark ?? null,
+        raw_data: { stats: metrics.rawStats },
+      });
+
+      if (error) {
+        // 23505 = unique_violation: a snapshot for this day_mark already exists.
+        if (error.code === "23505") {
+          return { duplicate: true };
+        }
+        throw new Error(
+          `Failed to insert performance_snapshots row: ${error.message}`
+        );
+      }
+
+      return { inserted: true };
+    });
+
+    return {
+      content_item_id,
+      day_mark: day_mark ?? null,
+      views: metrics.uniqueOpened,
+      reach: metrics.recipients,
+      clicks: metrics.uniqueClicked,
+      open_rate: metrics.openRate,
+      click_rate: metrics.clickRate,
+    };
+  }
+);

--- a/packages/inngest/src/functions/beehiiv-sync.ts
+++ b/packages/inngest/src/functions/beehiiv-sync.ts
@@ -1,0 +1,178 @@
+import { createClient } from "@supabase/supabase-js";
+import { decryptToken } from "@meridian/api";
+import { inngest } from "../client";
+
+// ─── Beehiiv API v2 response types ───────────────────────────────────────────
+
+interface BeehiivPost {
+  id: string;
+  publication_id: string;
+  title: string;
+  subtitle: string | null;
+  status: string;
+  /** Unix timestamp (seconds) of when the post was published. */
+  publish_date: number | null;
+  displayed_date: number | null;
+  slug: string;
+  thumbnail_url: string | null;
+  web_url: string | null;
+  audience: string;
+}
+
+interface BeehiivPostsResponse {
+  data: BeehiivPost[];
+  page: number;
+  limit: number;
+  total_results: number;
+  total_pages: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getSupabaseAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+/**
+ * Converts a Beehiiv Unix timestamp (seconds) to an ISO 8601 string.
+ * Returns null if the timestamp is missing or zero.
+ */
+function toIso(unixSeconds: number | null | undefined): string | null {
+  if (!unixSeconds) return null;
+  return new Date(unixSeconds * 1000).toISOString();
+}
+
+// ─── Inngest function ─────────────────────────────────────────────────────────
+
+/**
+ * Syncs all published Beehiiv newsletter posts for a connected publication
+ * into content_items.
+ *
+ * Triggered by: content/sync.requested  (platform === "beehiiv")
+ *
+ * Beehiiv uses API key authentication (no OAuth / token refresh). The
+ * encrypted API key is stored in access_token_enc; decrypted here for use.
+ *
+ * Only posts with status === "confirmed" (published) are imported. Posts
+ * are fetched page-by-page (100 per page) until all pages are exhausted.
+ *
+ * Steps:
+ *  1. fetch-platform          – Load connected_platforms row; decrypt API key.
+ *  2. sync-page-<N>           – One step per page of posts (100 items each).
+ *                               Each step upserts a batch into content_items.
+ */
+export const syncBeehiivPosts = inngest.createFunction(
+  {
+    id: "sync-beehiiv-posts",
+    name: "Sync Beehiiv Newsletter Posts",
+    retries: 3,
+  },
+  { event: "content/sync.requested", if: "event.data.platform == 'beehiiv'" },
+  async ({ event, step }) => {
+    const { creator_id, connected_platform_id, platform } = event.data;
+
+    if (platform !== "beehiiv") {
+      return { skipped: true, reason: "platform is not beehiiv" };
+    }
+
+    // ── Step 1: load the connected platform row and decrypt the API key ──────
+    const platformRow = await step.run("fetch-platform", async () => {
+      const supabase = getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from("connected_platforms")
+        .select("id, access_token_enc, platform_user_id")
+        .eq("id", connected_platform_id)
+        .single();
+
+      if (error || !data) {
+        throw new Error(
+          `Connected platform not found (id=${connected_platform_id}): ${error?.message}`
+        );
+      }
+
+      const apiKey = decryptToken(data.access_token_enc as string);
+
+      return {
+        id: data.id as string,
+        apiKey,
+        publicationId: data.platform_user_id as string,
+      };
+    });
+
+    const { apiKey, publicationId } = platformRow;
+
+    // ── Step 2+: paginate through published posts and upsert into content_items
+    let page = 1;
+    let totalPages = 1; // updated after the first response
+    let totalUpserted = 0;
+
+    do {
+      const currentPage = page;
+
+      const result = await step.run(`sync-page-${currentPage}`, async () => {
+        const supabase = getSupabaseAdmin();
+
+        const url = new URL(
+          `https://api.beehiiv.com/v2/publications/${encodeURIComponent(publicationId)}/posts`
+        );
+        url.searchParams.set("status", "confirmed");
+        url.searchParams.set("limit", "100");
+        url.searchParams.set("page", String(currentPage));
+
+        const res = await fetch(url.toString(), {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!res.ok) {
+          throw new Error(
+            `Beehiiv posts API failed (${res.status}): ${await res.text()}`
+          );
+        }
+
+        const body: BeehiivPostsResponse = await res.json();
+
+        if (body.data.length === 0) {
+          return { upserted: 0, totalPages: body.total_pages };
+        }
+
+        const rows = body.data.map((post) => ({
+          creator_id,
+          platform_id: connected_platform_id,
+          platform: "beehiiv" as const,
+          external_id: post.id,
+          title: post.title ?? null,
+          body: post.subtitle ?? null,
+          published_at: toIso(post.publish_date ?? post.displayed_date),
+          thumbnail_url: post.thumbnail_url ?? null,
+          duration_seconds: null,
+          raw_data: post,
+        }));
+
+        const { error, count } = await supabase
+          .from("content_items")
+          .upsert(rows, {
+            onConflict: "creator_id,platform,external_id",
+            count: "exact",
+          });
+
+        if (error) {
+          throw new Error(`content_items upsert failed: ${error.message}`);
+        }
+
+        return { upserted: count ?? rows.length, totalPages: body.total_pages };
+      });
+
+      totalPages = result.totalPages;
+      totalUpserted += result.upserted;
+      page++;
+    } while (page <= totalPages);
+
+    return { creator_id, connected_platform_id, totalUpserted };
+  }
+);

--- a/packages/inngest/src/functions/platform-connected.ts
+++ b/packages/inngest/src/functions/platform-connected.ts
@@ -30,6 +30,13 @@ export const handlePlatformConnected = inngest.createFunction(
       });
     }
 
+    if (platform === "beehiiv") {
+      await step.sendEvent("request-beehiiv-sync", {
+        name: "content/sync.requested",
+        data: { creator_id, connected_platform_id, platform },
+      });
+    }
+
     return { creator_id, platform };
   }
 );

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -20,3 +20,8 @@ export {
   instagramAnalyticsCron,
   fetchInstagramAnalyticsSnapshot,
 } from "./functions/instagram-analytics-cron";
+export { syncBeehiivPosts } from "./functions/beehiiv-sync";
+export {
+  beehiivAnalyticsCron,
+  fetchBeehiivAnalyticsSnapshot,
+} from "./functions/beehiiv-analytics-cron";

--- a/supabase/migrations/20260304000000_add_beehiiv.sql
+++ b/supabase/migrations/20260304000000_add_beehiiv.sql
@@ -1,0 +1,37 @@
+-- =============================================================
+-- Meridian – Add Beehiiv newsletter platform support
+-- Migration: 20260304000000_add_beehiiv.sql
+--
+-- Changes:
+--   1. Add 'beehiiv' to the platform_name enum so newsletter
+--      content can be stored alongside other platform content.
+--   2. Add newsletter-specific metrics columns to
+--      performance_snapshots: open_rate, click_rate, clicks.
+--      These are NULL for non-newsletter platforms.
+-- =============================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Add 'beehiiv' to the platform_name enum
+-- ---------------------------------------------------------------------------
+alter type platform_name add value if not exists 'beehiiv';
+
+-- ---------------------------------------------------------------------------
+-- 2. Add newsletter metrics to performance_snapshots
+--
+--   clicks     – unique recipients who clicked a link in the email
+--   open_rate  – percentage of recipients who opened (0–100)
+--   click_rate – percentage of recipients who clicked (0–100)
+-- ---------------------------------------------------------------------------
+alter table performance_snapshots
+  add column if not exists clicks    bigint,
+  add column if not exists open_rate numeric(6, 3),
+  add column if not exists click_rate numeric(6, 3);
+
+comment on column performance_snapshots.clicks is
+  'Unique recipients who clicked a link (newsletter / email platforms).';
+
+comment on column performance_snapshots.open_rate is
+  'Email open rate as a percentage (0–100). Populated for newsletter platforms.';
+
+comment on column performance_snapshots.click_rate is
+  'Email click rate as a percentage (0–100). Populated for newsletter platforms.';


### PR DESCRIPTION
## Summary
Adds full Beehiiv newsletter platform integration to Meridian, enabling creators to connect their Beehiiv publications, import newsletter posts, and track performance metrics (open rates, click rates, clicks) over time.

## Key Changes

**Platform Connection & Sync**
- New `/connect/beehiiv` page for API key + publication ID entry with validation against Beehiiv's API
- `POST /api/connect/beehiiv` endpoint that validates credentials, encrypts the API key, and persists the connection
- `syncBeehiivPosts` Inngest function that fetches all published posts from Beehiiv and upserts them into `content_items` with pagination support (100 posts per page)

**Analytics & Snapshots**
- `beehiivAnalyticsCron` daily cron (05:00 UTC) that identifies newsletter posts at lifecycle day marks (1, 7, 30 days post-publication) and dispatches snapshot requests
- `fetchBeehiivAnalyticsSnapshot` function that fetches post stats from Beehiiv's API and stores performance metrics in `performance_snapshots`
- Metric mapping: email opens → `views`, recipients → `reach`, unique clicks → `clicks`, plus `open_rate` and `click_rate` percentages

**Database & Schema**
- Added `beehiiv` to the `platform_name` enum type
- Extended `performance_snapshots` table with newsletter-specific columns: `clicks`, `open_rate`, `click_rate`
- Migration file `20250304000000_add_beehiiv.sql` handles schema changes

**Integration**
- Updated `platform/connected` handler to trigger content sync for Beehiiv
- Registered new Inngest functions in the API route handler
- Updated `/connect` page to display Beehiiv as a connection option with appropriate UI

## Implementation Details

- Beehiiv uses long-lived API keys (no OAuth/token refresh), encrypted at rest using AES-256-GCM
- Posts are identified by `external_id` (Beehiiv post ID) and synced via upsert to avoid duplicates
- Analytics snapshots use a ±12-hour window around each day mark to account for timezone variations
- Duplicate snapshot detection via PostgreSQL unique constraint (23505 error handling)
- Concurrency limit of 5 for snapshot fetches to manage API rate limits

https://claude.ai/code/session_01HQRxW4WcFX8ZStAFFBcsHG