### PR TITLE
Add platform connections management page with sync tracking

### DIFF
--- a/apps/web/app/settings/connections/actions.ts
+++ b/apps/web/app/settings/connections/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createServerClient } from "@/lib/supabase/server";
+
+/**
+ * Disconnects a platform by clearing its tokens and marking status as
+ * 'disconnected'. The row is preserved so re-connection history is retained.
+ */
+export async function disconnectPlatform(platform: string) {
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return;
+
+  const { data: creator } = await supabase
+    .from("creators")
+    .select("id")
+    .eq("auth_user_id", user.id)
+    .single();
+
+  if (!creator) return;
+
+  await supabase
+    .from("connected_platforms")
+    .update({
+      status: "disconnected",
+      access_token_enc: null,
+      refresh_token_enc: null,
+      token_expires_at: null,
+    })
+    .eq("creator_id", creator.id)
+    .eq("platform", platform);
+
+  revalidatePath("/settings/connections");
+}

--- a/apps/web/app/settings/connections/page.tsx
+++ b/apps/web/app/settings/connections/page.tsx
@@ -1,0 +1,298 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createServerClient } from "@/lib/supabase/server";
+import { disconnectPlatform } from "./actions";
+
+/**
+ * /settings/connections – Platform connection status page
+ *
+ * Shows every supported platform as a card with:
+ *  - Platform icon (coloured indicator), name, and connected account username
+ *  - Status badge: Connected | Re-auth required | Disconnected
+ *  - Last synced timestamp
+ *  - Connect / Reconnect / Disconnect action buttons
+ */
+
+// ─── Platform config ──────────────────────────────────────────────────────────
+
+interface PlatformConfig {
+  label: string;
+  color: string;
+  connectHref: string;
+  description: string;
+}
+
+const PLATFORMS: Record<string, PlatformConfig> = {
+  youtube: {
+    label: "YouTube",
+    color: "#dc2626",
+    connectHref: "/api/connect/youtube",
+    description: "Videos and channel analytics",
+  },
+  instagram: {
+    label: "Instagram",
+    color: "#7c3aed",
+    connectHref: "/api/connect/instagram",
+    description: "Posts and performance insights",
+  },
+  beehiiv: {
+    label: "Beehiiv",
+    color: "#f97316",
+    connectHref: "/connect/beehiiv",
+    description: "Newsletter posts, open rates and clicks",
+  },
+};
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, { background: string; color: string; label: string }> = {
+    active: { background: "#f0fdf4", color: "#15803d", label: "Connected" },
+    reauth_required: { background: "#fffbeb", color: "#92400e", label: "Re-auth required" },
+    disconnected: { background: "#f3f4f6", color: "#6b7280", label: "Disconnected" },
+  };
+
+  const s = styles[status] ?? styles.disconnected;
+
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 10px",
+        borderRadius: 99,
+        fontSize: 12,
+        fontWeight: 600,
+        background: s.background,
+        color: s.color,
+      }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
+function formatRelativeTime(iso: string | null): string {
+  if (!iso) return "Never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "Just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+interface ConnectedPlatformRow {
+  platform: string;
+  platform_username: string | null;
+  status: string;
+  last_synced_at: string | null;
+}
+
+export default async function ConnectionsPage() {
+  const supabase = await createServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: creator } = await supabase
+    .from("creators")
+    .select("id")
+    .eq("auth_user_id", user.id)
+    .single();
+
+  let connectedRows: ConnectedPlatformRow[] = [];
+
+  if (creator) {
+    const { data } = await supabase
+      .from("connected_platforms")
+      .select("platform, platform_username, status, last_synced_at")
+      .eq("creator_id", creator.id)
+      .in("platform", Object.keys(PLATFORMS));
+
+    connectedRows = (data ?? []) as ConnectedPlatformRow[];
+  }
+
+  // Build a lookup by platform key for O(1) access in render
+  const connectionByPlatform = Object.fromEntries(
+    connectedRows.map((row) => [row.platform, row])
+  );
+
+  return (
+    <main
+      style={{
+        maxWidth: 560,
+        margin: "64px auto",
+        padding: "0 24px",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      {/* ── Header ── */}
+      <div style={{ marginBottom: 32 }}>
+        <Link
+          href="/"
+          style={{ display: "inline-block", marginBottom: 20, fontSize: 14, color: "#6b7280", textDecoration: "none" }}
+        >
+          ← Back
+        </Link>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: "0 0 6px" }}>
+          Platform connections
+        </h1>
+        <p style={{ color: "#6b7280", margin: 0, fontSize: 15 }}>
+          Manage the accounts Meridian syncs content and analytics from.
+        </p>
+      </div>
+
+      {/* ── Platform cards ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {Object.entries(PLATFORMS).map(([key, cfg]) => {
+          const conn = connectionByPlatform[key] ?? null;
+          const status = conn?.status ?? "disconnected";
+          const isConnected = status !== "disconnected";
+          const needsReauth = status === "reauth_required";
+
+          return (
+            <div
+              key={key}
+              style={{
+                border: `1px solid ${needsReauth ? "#fcd34d" : "#e5e7eb"}`,
+                borderRadius: 12,
+                padding: 20,
+                background: needsReauth ? "#fffdf5" : "#fff",
+              }}
+            >
+              {/* Top row: icon + name + badge */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  marginBottom: 12,
+                }}
+              >
+                {/* Platform colour dot */}
+                <div
+                  aria-hidden
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 8,
+                    background: cfg.color,
+                    flexShrink: 0,
+                  }}
+                />
+
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    <span style={{ fontWeight: 700, fontSize: 16 }}>
+                      {cfg.label}
+                    </span>
+                    <StatusBadge status={status} />
+                  </div>
+
+                  {conn?.platform_username ? (
+                    <div
+                      style={{
+                        fontSize: 13,
+                        color: "#6b7280",
+                        marginTop: 2,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {conn.platform_username}
+                    </div>
+                  ) : (
+                    <div style={{ fontSize: 13, color: "#9ca3af", marginTop: 2 }}>
+                      {cfg.description}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Last synced row */}
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "#9ca3af",
+                  marginBottom: 14,
+                }}
+              >
+                {isConnected ? (
+                  <>Last synced: {formatRelativeTime(conn?.last_synced_at ?? null)}</>
+                ) : (
+                  "Not connected"
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {/* Connect / Reconnect */}
+                <a
+                  href={cfg.connectHref}
+                  style={{
+                    display: "inline-block",
+                    background: isConnected ? "#f3f4f6" : cfg.color,
+                    color: isConnected ? "#374151" : "#fff",
+                    padding: "7px 16px",
+                    borderRadius: 6,
+                    textDecoration: "none",
+                    fontWeight: 600,
+                    fontSize: 13,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {needsReauth ? "Reconnect" : isConnected ? "Reconnect" : "Connect"}
+                </a>
+
+                {/* Disconnect — only shown when connected */}
+                {isConnected && (
+                  <form
+                    action={async () => {
+                      "use server";
+                      await disconnectPlatform(key);
+                    }}
+                  >
+                    <button
+                      type="submit"
+                      style={{
+                        background: "transparent",
+                        color: "#ef4444",
+                        padding: "7px 16px",
+                        borderRadius: 6,
+                        border: "1px solid #fca5a5",
+                        fontWeight: 600,
+                        fontSize: 13,
+                        cursor: "pointer",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      Disconnect
+                    </button>
+                  </form>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </main>
+  );
+}

--- a/packages/inngest/src/functions/beehiiv-sync.ts
+++ b/packages/inngest/src/functions/beehiiv-sync.ts
@@ -173,6 +173,15 @@ export const syncBeehiivPosts = inngest.createFunction(
       page++;
     } while (page <= totalPages);
 
+    // ── Final step: stamp last_synced_at on the connected_platforms row ───────
+    await step.run("mark-synced", async () => {
+      const supabase = getSupabaseAdmin();
+      await supabase
+        .from("connected_platforms")
+        .update({ last_synced_at: new Date().toISOString() })
+        .eq("id", connected_platform_id);
+    });
+
     return { creator_id, connected_platform_id, totalUpserted };
   }
 );

--- a/packages/inngest/src/functions/instagram-sync.ts
+++ b/packages/inngest/src/functions/instagram-sync.ts
@@ -195,6 +195,15 @@ export const syncInstagramMedia = inngest.createFunction(
       if (pageIndex >= 200) break;
     } while (cursor);
 
+    // ── Final step: stamp last_synced_at on the connected_platforms row ───────
+    await step.run("mark-synced", async () => {
+      const supabase = getSupabaseAdmin();
+      await supabase
+        .from("connected_platforms")
+        .update({ last_synced_at: new Date().toISOString() })
+        .eq("id", connected_platform_id);
+    });
+
     return { creator_id, connected_platform_id, totalUpserted };
   }
 );

--- a/packages/inngest/src/functions/youtube-sync.ts
+++ b/packages/inngest/src/functions/youtube-sync.ts
@@ -269,6 +269,15 @@ export const syncYoutubeMetadata = inngest.createFunction(
       totalUpserted += result.upserted;
     } while (pageToken);
 
+    // ── Final step: stamp last_synced_at on the connected_platforms row ───────
+    await step.run("mark-synced", async () => {
+      const supabase = getSupabaseAdmin();
+      await supabase
+        .from("connected_platforms")
+        .update({ last_synced_at: new Date().toISOString() })
+        .eq("id", connected_platform_id);
+    });
+
     return { creator_id, connected_platform_id, totalUpserted };
   }
 );

--- a/supabase/migrations/20260304000001_add_last_synced_at.sql
+++ b/supabase/migrations/20260304000001_add_last_synced_at.sql
@@ -1,0 +1,14 @@
+-- =============================================================
+-- Meridian – Add last_synced_at to connected_platforms
+-- Migration: 20260304000001_add_last_synced_at.sql
+--
+-- Adds a last_synced_at timestamp to connected_platforms so the
+-- Settings > Connections page can show when each platform was last
+-- successfully synced.
+-- =============================================================
+
+alter table connected_platforms
+  add column if not exists last_synced_at timestamptz;
+
+comment on column connected_platforms.last_synced_at is
+  'Timestamp of the most recent successful content sync for this platform connection.';


### PR DESCRIPTION
## Summary
This PR adds a new Settings > Connections page that allows users to view and manage their connected platform accounts (YouTube, Instagram, Beehiiv). It includes sync status tracking and the ability to connect, reconnect, or disconnect platforms.

## Key Changes

- **New Settings Page** (`/settings/connections`)
  - Displays all supported platforms as cards with connection status, username, and last sync timestamp
  - Shows three status states: Connected, Re-auth required, Disconnected
  - Provides Connect/Reconnect/Disconnect action buttons for each platform
  - Responsive design with platform-specific color indicators

- **Disconnect Action** (`disconnectPlatform` server action)
  - Clears authentication tokens and marks platform as disconnected
  - Preserves the connection record for history retention
  - Revalidates the connections page after disconnect

- **Sync Tracking**
  - Added `last_synced_at` column to `connected_platforms` table via migration
  - Updated all three sync functions (YouTube, Instagram, Beehiiv) to stamp `last_synced_at` timestamp upon successful completion
  - Displays relative time formatting (e.g., "2h ago", "3d ago") on the connections page

## Implementation Details

- Uses inline styles for the connections page UI (no external CSS dependencies)
- Implements O(1) lookup of connection data by platform key for efficient rendering
- Handles edge cases: null usernames, missing sync timestamps, re-authentication requirements
- All sync functions follow the same pattern for marking completion, ensuring consistency across platforms

https://claude.ai/code/session_01BpoYKDFZM1mfrHtYYhvhXs