### PR TITLE
Add content type filtering to creator dashboard

### DIFF
--- a/apps/web/app/ContentTypeFilter.tsx
+++ b/apps/web/app/ContentTypeFilter.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { ContentType } from "@meridian/types";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const CONTENT_TYPES: { type: ContentType; label: string }[] = [
+  { type: "video", label: "Video" },
+  { type: "short", label: "Short" },
+  { type: "newsletter", label: "Newsletter" },
+  { type: "podcast", label: "Podcast" },
+];
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ContentTypeFilterProps {
+  selected: ContentType[];
+  onChange: (types: ContentType[]) => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export default function ContentTypeFilter({
+  selected,
+  onChange,
+}: ContentTypeFilterProps) {
+  function toggle(type: ContentType) {
+    if (selected.includes(type)) {
+      onChange(selected.filter((t) => t !== type));
+    } else {
+      onChange([...selected, type]);
+    }
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="Filter by content type"
+      style={{ display: "flex", gap: 8, flexWrap: "wrap" }}
+    >
+      {CONTENT_TYPES.map(({ type, label }) => {
+        const active = selected.includes(type);
+        return (
+          <button
+            key={type}
+            onClick={() => toggle(type)}
+            aria-pressed={active}
+            style={{
+              padding: "5px 14px",
+              borderRadius: 9999,
+              border: "1px solid",
+              borderColor: active ? "#2563eb" : "#d1d5db",
+              background: active ? "#eff6ff" : "#fff",
+              color: active ? "#1d4ed8" : "#374151",
+              fontWeight: active ? 600 : 400,
+              fontSize: 13,
+              cursor: "pointer",
+              transition: "all 0.1s",
+              userSelect: "none",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/app/CreatorDashboard.tsx
+++ b/apps/web/app/CreatorDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   BarChart,
   Bar,
@@ -12,6 +13,9 @@ import {
 } from "recharts";
 import ContentMetricsTable from "./ContentMetricsTable";
 import ConsistencyHeatmap from "./ConsistencyHeatmap";
+import ContentTypeFilter from "./ContentTypeFilter";
+import type { ContentType } from "@meridian/types";
+import { CONTENT_TYPE_PLATFORMS } from "@meridian/types";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -42,6 +46,8 @@ const PLATFORM_COLORS: Record<string, string> = {
   tiktok: "#000000",
 };
 
+const TYPES_PARAM = "types";
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function formatNumber(n: number): string {
@@ -54,15 +60,66 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max - 1) + "…" : s;
 }
 
+/** Derive a platform's content type so we can filter by content type. */
+function platformToContentType(platform: string): ContentType | null {
+  for (const [type, platforms] of Object.entries(CONTENT_TYPE_PLATFORMS) as [
+    ContentType,
+    string[],
+  ][]) {
+    if (platforms.includes(platform)) return type;
+  }
+  return null;
+}
+
+/** Parse valid ContentType values out of a comma-separated URL param value. */
+function parseTypesParam(value: string | null): ContentType[] {
+  if (!value) return [];
+  const valid = new Set<ContentType>(["video", "short", "newsletter", "podcast"]);
+  return value
+    .split(",")
+    .filter((v): v is ContentType => valid.has(v as ContentType));
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function CreatorDashboard({ content }: DashboardProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [period, setPeriod] = useState<Period>("30d");
 
+  // Content type filter — persisted in the `types` URL param
+  const selectedTypes = useMemo(
+    () => parseTypesParam(searchParams.get(TYPES_PARAM)),
+    [searchParams],
+  );
+
+  function handleTypesChange(types: ContentType[]) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (types.length > 0) {
+      params.set(TYPES_PARAM, types.join(","));
+    } else {
+      params.delete(TYPES_PARAM);
+    }
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }
+
+  // Apply content type filter first (all-time, for the table + heatmap)
+  const typeFiltered = useMemo(() => {
+    if (selectedTypes.length === 0) return content;
+    return content.filter((c) => {
+      const ct = platformToContentType(c.platform);
+      return ct !== null && selectedTypes.includes(ct);
+    });
+  }, [content, selectedTypes]);
+
+  // Then apply the period window for cards + bar chart
   const filtered = useMemo(() => {
     const cutoff = Date.now() - PERIOD_DAYS[period] * 86_400_000;
-    return content.filter((c) => new Date(c.publishedAt).getTime() >= cutoff);
-  }, [content, period]);
+    return typeFiltered.filter(
+      (c) => new Date(c.publishedAt).getTime() >= cutoff,
+    );
+  }, [typeFiltered, period]);
 
   const totalViews = useMemo(
     () => filtered.reduce((sum, c) => sum + c.totalViews, 0),
@@ -140,7 +197,15 @@ export default function CreatorDashboard({ content }: DashboardProps) {
           marginBottom: 36,
         }}
       >
-        <ConsistencyHeatmap content={content} />
+        <ConsistencyHeatmap content={typeFiltered} />
+      </div>
+
+      {/* ── Content type filter ── */}
+      <div style={{ marginBottom: 20 }}>
+        <ContentTypeFilter
+          selected={selectedTypes}
+          onChange={handleTypesChange}
+        />
       </div>
 
       {/* ── Period filter ── */}
@@ -250,13 +315,14 @@ export default function CreatorDashboard({ content }: DashboardProps) {
       {filtered.length === 0 && (
         <p style={{ color: "#9ca3af", textAlign: "center", marginTop: 24 }}>
           No content published in the last{" "}
-          {period === "7d" ? "7" : period === "30d" ? "30" : "90"} days.
+          {period === "7d" ? "7" : period === "30d" ? "30" : "90"} days
+          {selectedTypes.length > 0 ? " for the selected content type(s)" : ""}.
         </p>
       )}
 
       {/* ── Content metrics table ── */}
       <div style={{ marginTop: 48 }}>
-        <ContentMetricsTable rows={content} />
+        <ContentMetricsTable rows={typeFiltered} />
       </div>
     </div>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { createServerClient } from "@/lib/supabase/server";
 import CreatorDashboard from "./CreatorDashboard";
@@ -184,7 +185,9 @@ export default async function Home() {
         </p>
       </div>
 
-      <CreatorDashboard content={dashboardContent} />
+      <Suspense>
+        <CreatorDashboard content={dashboardContent} />
+      </Suspense>
     </main>
   );
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,16 @@
 
 export type Platform = "youtube" | "instagram" | "tiktok" | "beehiiv";
 
+export type ContentType = "video" | "short" | "newsletter" | "podcast";
+
+/** Maps each content type to the platform identifier(s) that produce it. */
+export const CONTENT_TYPE_PLATFORMS: Record<ContentType, string[]> = {
+  video: ["youtube"],
+  short: ["instagram", "tiktok"],
+  newsletter: ["beehiiv"],
+  podcast: ["podcast"],
+};
+
 export type ConnectionStatus = "active" | "reauth_required" | "disconnected";
 
 export type RepurposeJobStatus =


### PR DESCRIPTION
## Summary
Added the ability to filter dashboard content by content type (video, short, newsletter, podcast). The filter state is persisted in the URL query parameters, allowing users to bookmark and share filtered views.

## Key Changes
- **New `ContentTypeFilter` component** (`apps/web/app/ContentTypeFilter.tsx`): A multi-select button group for filtering by content type with visual feedback for active selections
- **Content type definitions** (`packages/types/src/index.ts`): Added `ContentType` type and `CONTENT_TYPE_PLATFORMS` mapping to associate platforms with their content types
- **Dashboard filtering logic** (`apps/web/app/CreatorDashboard.tsx`):
  - Integrated URL parameter parsing for the `types` query param
  - Implemented two-stage filtering: first by content type (all-time), then by period window
  - Updated all data consumers (heatmap, metrics table, empty state message) to use filtered content
  - Added `handleTypesChange` handler to update URL state without page scroll
- **Server component wrapping** (`apps/web/app/page.tsx`): Wrapped `CreatorDashboard` in `Suspense` boundary to support client-side navigation hooks

## Implementation Details
- Content type filtering is applied before period filtering, ensuring the heatmap and metrics table show all-time data for selected types while cards/charts respect the period window
- The `platformToContentType` helper dynamically maps platforms to content types using the centralized `CONTENT_TYPE_PLATFORMS` mapping
- URL state management uses `useRouter` and `useSearchParams` from `next/navigation` for seamless query parameter updates
- Filter state is memoized based on search params to prevent unnecessary recalculations

https://claude.ai/code/session_01AnFnRYWrYZkxxYvxCHubx5