### PR TITLE
Add metrics normalization layer for cross-platform comparisons

### DIFF
--- a/packages/inngest/src/functions/beehiiv-analytics-cron.ts
+++ b/packages/inngest/src/functions/beehiiv-analytics-cron.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { decryptToken } from "@meridian/api";
 import { inngest } from "../client";
+import { normalizeMetrics } from "../lib/normalizeMetrics";
 
 // ─── Beehiiv API v2 response types ───────────────────────────────────────────
 
@@ -324,11 +325,25 @@ export const fetchBeehiivAnalyticsSnapshot = inngest.createFunction(
     await step.run("store-snapshot", async () => {
       const supabase = getSupabaseAdmin();
 
+      // Normalise platform-native metrics into the canonical schema.
+      // Beehiiv mapping:
+      //   views              ← uniqueOpened (unique email opens ≈ "unique content views")
+      //   engagement_rate    ← openRate / 100 (convert percentage → fraction)
+      //   watch_time_seconds ← null (email newsletters have no watch-time concept)
+      const normalized = normalizeMetrics({
+        platform: "beehiiv",
+        uniqueOpened: metrics.uniqueOpened,
+        recipients: metrics.recipients,
+        openRate: metrics.openRate,
+      });
+
       const { error } = await supabase.from("performance_snapshots").insert({
         content_item_id,
         creator_id,
         // Map newsletter metrics to the shared performance_snapshots schema.
-        views: metrics.uniqueOpened,
+        views: normalized.views,
+        engagement_rate: normalized.engagement_rate,
+        // watch_time_seconds is null for Beehiiv; leave watch_time_minutes unset.
         reach: metrics.recipients,
         clicks: metrics.uniqueClicked,
         open_rate: metrics.openRate,

--- a/packages/inngest/src/functions/instagram-analytics-cron.ts
+++ b/packages/inngest/src/functions/instagram-analytics-cron.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { inngest } from "../client";
 import { ensureValidInstagramToken } from "../lib/refreshInstagramToken";
+import { normalizeMetrics } from "../lib/normalizeMetrics";
 
 // ─── Instagram Insights API response types ────────────────────────────────────
 
@@ -391,15 +392,31 @@ export const fetchInstagramAnalyticsSnapshot = inngest.createFunction(
     await step.run("store-snapshot", async () => {
       const supabase = getSupabaseAdmin();
 
-      const { error } = await supabase.from("performance_snapshots").insert({
-        content_item_id,
-        creator_id,
+      // Normalise platform-native metrics into the canonical schema.
+      // Instagram mapping:
+      //   views              ← views (Meta's unified metric, Apr 2025)
+      //   engagement_rate    ← (likes + comments + shares + saves) / views
+      //   watch_time_seconds ← null (not exposed by the Instagram API)
+      const normalized = normalizeMetrics({
+        platform: "instagram",
         views: metrics.views,
         likes: metrics.likes,
         comments: metrics.comments,
         shares: metrics.shares,
         saves: metrics.saves,
+      });
+
+      const { error } = await supabase.from("performance_snapshots").insert({
+        content_item_id,
+        creator_id,
+        views: normalized.views,
+        likes: metrics.likes,
+        comments: metrics.comments,
+        shares: metrics.shares,
+        saves: metrics.saves,
         reach: metrics.reach,
+        engagement_rate: normalized.engagement_rate,
+        // watch_time_seconds is null for Instagram; leave watch_time_minutes unset.
         // Meta's `views` metric is the post-deprecation replacement for
         // `impressions` (images) and `plays` (videos/Reels) as of Apr 2025.
         // We store it in both columns so the normalised schema remains

--- a/packages/inngest/src/functions/youtube-analytics-cron.ts
+++ b/packages/inngest/src/functions/youtube-analytics-cron.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { inngest } from "../client";
 import { ensureValidYouTubeToken } from "../lib/refreshYouTubeToken";
+import { normalizeMetrics } from "../lib/normalizeMetrics";
 
 // ─── YouTube Analytics API response type ─────────────────────────────────────
 
@@ -366,13 +367,32 @@ export const fetchYoutubeAnalyticsSnapshot = inngest.createFunction(
     await step.run("store-snapshot", async () => {
       const supabase = getSupabaseAdmin();
 
-      const { error } = await supabase.from("performance_snapshots").insert({
-        content_item_id,
-        creator_id,
+      // Normalise platform-native metrics into the canonical schema.
+      // YouTube mapping:
+      //   views              ← views (direct)
+      //   engagement_rate    ← (likes + comments + shares) / views
+      //   watch_time_seconds ← estimatedMinutesWatched × 60
+      const normalized = normalizeMetrics({
+        platform: "youtube",
         views: metrics.views,
+        estimatedMinutesWatched: metrics.estimatedMinutesWatched,
         likes: metrics.likes,
         comments: metrics.comments,
         shares: metrics.shares,
+      });
+
+      const { error } = await supabase.from("performance_snapshots").insert({
+        content_item_id,
+        creator_id,
+        views: normalized.views,
+        likes: metrics.likes,
+        comments: metrics.comments,
+        shares: metrics.shares,
+        engagement_rate: normalized.engagement_rate,
+        // DB column stores minutes; convert from normalized seconds.
+        watch_time_minutes: normalized.watch_time_seconds !== null
+          ? normalized.watch_time_seconds / 60
+          : null,
         day_mark: day_mark ?? null,
         raw_data: {
           estimated_minutes_watched: metrics.estimatedMinutesWatched,

--- a/packages/inngest/src/index.ts
+++ b/packages/inngest/src/index.ts
@@ -8,6 +8,15 @@
 export { INNGEST_APP_ID, inngest } from "./client";
 export type { MeridianEvents } from "./events";
 
+// ─── Metrics normalisation layer ─────────────────────────────────────────────
+export { normalizeMetrics } from "./lib/normalizeMetrics";
+export type {
+  PlatformRawMetrics,
+  YouTubeRawMetrics,
+  InstagramRawMetrics,
+  BeehiivRawMetrics,
+} from "./lib/normalizeMetrics";
+
 // ─── Background function handlers ────────────────────────────────────────────
 export { syncYoutubeMetadata } from "./functions/youtube-sync";
 export { handlePlatformConnected } from "./functions/platform-connected";

--- a/packages/inngest/src/lib/normalizeMetrics.ts
+++ b/packages/inngest/src/lib/normalizeMetrics.ts
@@ -1,0 +1,228 @@
+/**
+ * Metrics Normalisation Layer
+ *
+ * Each platform reports analytics in its own schema with different field names,
+ * units, and engagement definitions. This module maps every platform's raw API
+ * response into a single `NormalizedMetrics` shape so that cross-platform
+ * comparisons are apples-to-apples.
+ *
+ * Canonical output schema
+ * ─────────────────────────────────────────────────────────────────────────────
+ *  views              integer       Total view / open count (≥ 0).
+ *  engagement_rate    float [0, 1]  Ratio of interactions to views.
+ *  watch_time_seconds number | null Cumulative watch time in seconds;
+ *                                   null for platforms without this data.
+ *
+ * Platform mapping summary
+ * ─────────────────────────────────────────────────────────────────────────────
+ *  Platform    views                engagement_rate                      watch_time_seconds
+ *  ─────────── ──────────────────── ──────────────────────────────────── ──────────────────
+ *  YouTube     views                (likes+comments+shares) / views      estimatedMinutesWatched × 60
+ *  Instagram   views (unified)*     (likes+comments+shares+saves)/views  null
+ *  Beehiiv     unique_opened        open_rate / 100                      null
+ *
+ *  * Meta replaced the deprecated `impressions` (images) and `plays`
+ *    (videos/Reels) with a single `views` metric on April 21, 2025.
+ */
+
+import type { NormalizedMetrics } from "@meridian/types";
+
+// ─── Raw platform metric shapes ───────────────────────────────────────────────
+
+/**
+ * Raw metrics as returned by the YouTube Analytics API /reports endpoint.
+ *
+ * Columns requested: views, estimatedMinutesWatched, likes, comments, shares
+ * Each value is drawn from the first row of the API response:
+ *   row = [videoId, views, estimatedMinutesWatched, likes, comments, shares]
+ */
+export interface YouTubeRawMetrics {
+  platform: "youtube";
+  /** Total view count for the cumulative date range. Maps to normalized `views`. */
+  views: number;
+  /**
+   * Cumulative watch time in minutes (YouTube's native unit).
+   * Multiplied by 60 to produce normalized `watch_time_seconds`.
+   */
+  estimatedMinutesWatched: number;
+  /** Interaction signal for engagement_rate numerator. */
+  likes: number;
+  /** Interaction signal for engagement_rate numerator. */
+  comments: number;
+  /** Interaction signal for engagement_rate numerator. */
+  shares: number;
+}
+
+/**
+ * Raw metrics as returned by the Instagram Graph API.
+ *
+ * `views` is Meta's unified metric (introduced April 21, 2025):
+ *   — images / carousels: counts impressions (unique accounts that saw the post)
+ *   — videos / Reels: counts plays
+ * It replaces the now-deprecated `impressions` and `plays` fields.
+ *
+ * `likes` and `comments` are fetched directly from the media object
+ * (like_count / comments_count), not from the Insights endpoint.
+ *
+ * `saves` are included in the engagement numerator because on Instagram they
+ * represent strong intent (a user bookmarking content for later), which is a
+ * meaningful engagement signal absent from other platforms.
+ */
+export interface InstagramRawMetrics {
+  platform: "instagram";
+  /**
+   * Meta's unified reach/play metric (Apr 2025 migration).
+   * Maps directly to normalized `views`.
+   */
+  views: number;
+  /** Interaction signal for engagement_rate numerator. */
+  likes: number;
+  /** Interaction signal for engagement_rate numerator. */
+  comments: number;
+  /** Interaction signal for engagement_rate numerator. */
+  shares: number;
+  /**
+   * Saves / bookmarks. Counted in the engagement_rate numerator alongside
+   * likes, comments, and shares — saves signal strong user intent on Instagram.
+   */
+  saves: number;
+}
+
+/**
+ * Raw metrics as returned by the Beehiiv API v2
+ * GET /publications/{id}/posts/{id}?expand[]=stats
+ *
+ * Beehiiv is an email newsletter platform. Watch time and video-centric
+ * engagement concepts do not apply. The email `open_rate` is the closest
+ * analogue to "a reader engaged with this content", so it serves as the
+ * engagement_rate proxy.
+ *
+ * open_rate is returned as a percentage (e.g. 42.5 means 42.5 %).
+ */
+export interface BeehiivRawMetrics {
+  platform: "beehiiv";
+  /**
+   * Number of unique subscribers who opened the email.
+   * Maps to normalized `views` — the most direct analogue to "unique content
+   * views" in an email context.
+   */
+  uniqueOpened: number;
+  /**
+   * Total recipients at send time (list size). Retained for context but not
+   * used in the current engagement formula; open_rate already encodes
+   * uniqueOpened / recipients as a pre-computed percentage.
+   */
+  recipients: number;
+  /**
+   * Pre-computed open rate as a percentage (0–100).
+   * Divided by 100 to produce normalized `engagement_rate` (fraction 0–1).
+   */
+  openRate: number;
+}
+
+// ─── Discriminated union of all supported platforms ───────────────────────────
+
+export type PlatformRawMetrics =
+  | YouTubeRawMetrics
+  | InstagramRawMetrics
+  | BeehiivRawMetrics;
+
+// ─── Public normaliser ────────────────────────────────────────────────────────
+
+/**
+ * Converts platform-native raw metrics into the canonical `NormalizedMetrics`
+ * schema so that cross-platform comparisons are apples-to-apples.
+ *
+ * `engagement_rate` is always clamped to [0, 1] as a defensive measure against
+ * API anomalies (e.g. bot-inflated interactions exceeding the view count).
+ *
+ * `views` is always rounded to the nearest integer because some platform APIs
+ * return floating-point counts after internal normalisation on their side.
+ *
+ * @example
+ *   const normalized = normalizeMetrics({
+ *     platform: "youtube",
+ *     views: 10_000,
+ *     estimatedMinutesWatched: 25_000,
+ *     likes: 800,
+ *     comments: 120,
+ *     shares: 80,
+ *   });
+ *   // { views: 10000, engagement_rate: 0.1, watch_time_seconds: 1500000 }
+ */
+export function normalizeMetrics(raw: PlatformRawMetrics): NormalizedMetrics {
+  switch (raw.platform) {
+    case "youtube":
+      return normalizeYouTube(raw);
+    case "instagram":
+      return normalizeInstagram(raw);
+    case "beehiiv":
+      return normalizeBeehiiv(raw);
+  }
+}
+
+// ─── Per-platform implementations ─────────────────────────────────────────────
+
+/**
+ * YouTube → NormalizedMetrics
+ *
+ *  views              ← views (direct, rounded)
+ *  engagement_rate    ← (likes + comments + shares) / views, clamped [0, 1]
+ *                       0 when views === 0 (avoids division by zero)
+ *  watch_time_seconds ← estimatedMinutesWatched × 60
+ *                       (convert YouTube's native minutes unit to seconds)
+ */
+function normalizeYouTube(raw: YouTubeRawMetrics): NormalizedMetrics {
+  const interactions = raw.likes + raw.comments + raw.shares;
+  const engagement_rate =
+    raw.views > 0 ? clamp(interactions / raw.views, 0, 1) : 0;
+
+  return {
+    views: Math.round(raw.views),
+    engagement_rate,
+    watch_time_seconds: Math.round(raw.estimatedMinutesWatched * 60),
+  };
+}
+
+/**
+ * Instagram → NormalizedMetrics
+ *
+ *  views              ← views (Meta's unified metric, Apr 2025; direct, rounded)
+ *  engagement_rate    ← (likes + comments + shares + saves) / views, clamped [0, 1]
+ *                       saves are included because they signal strong intent on Instagram
+ *                       0 when views === 0 (avoids division by zero)
+ *  watch_time_seconds ← null (Instagram does not expose watch time via the API)
+ */
+function normalizeInstagram(raw: InstagramRawMetrics): NormalizedMetrics {
+  const interactions = raw.likes + raw.comments + raw.shares + raw.saves;
+  const engagement_rate =
+    raw.views > 0 ? clamp(interactions / raw.views, 0, 1) : 0;
+
+  return {
+    views: Math.round(raw.views),
+    engagement_rate,
+    watch_time_seconds: null,
+  };
+}
+
+/**
+ * Beehiiv → NormalizedMetrics
+ *
+ *  views              ← uniqueOpened (unique email opens ≈ "unique content views")
+ *  engagement_rate    ← openRate / 100
+ *                       Beehiiv's openRate is a percentage (e.g. 42.5 → 0.425)
+ *  watch_time_seconds ← null (email newsletters have no watch-time concept)
+ */
+function normalizeBeehiiv(raw: BeehiivRawMetrics): NormalizedMetrics {
+  return {
+    views: Math.round(raw.uniqueOpened),
+    engagement_rate: clamp(raw.openRate / 100, 0, 1),
+    watch_time_seconds: null,
+  };
+}
+
+// ─── Utility ──────────────────────────────────────────────────────────────────
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -97,6 +97,26 @@ export interface PatternInsight {
   updated_at: string;
 }
 
+/**
+ * Platform-agnostic metrics produced by the normalisation layer.
+ *
+ * All platform-native metric schemas are mapped to this consistent shape so
+ * that cross-platform comparisons are apples-to-apples.
+ *
+ * Fields
+ * ──────
+ *  views              — Total view / open count (integer ≥ 0).
+ *  engagement_rate    — Ratio of interactions to views, clamped to [0, 1].
+ *                       Calculated per-platform (see normalizeMetrics docs).
+ *  watch_time_seconds — Cumulative watch time in seconds. `null` for platforms
+ *                       that do not expose this data (Instagram, Beehiiv).
+ */
+export interface NormalizedMetrics {
+  views: number;
+  engagement_rate: number;
+  watch_time_seconds: number | null;
+}
+
 export interface RepurposeJob {
   id: string;
   creator_id: string;


### PR DESCRIPTION
## Summary

Introduces a platform-agnostic metrics normalisation layer that converts platform-native analytics schemas (YouTube, Instagram, Beehiiv) into a canonical `NormalizedMetrics` shape. This enables consistent cross-platform comparisons and reduces schema duplication across analytics pipelines.

## Key Changes

- **New normalisation module** (`packages/inngest/src/lib/normalizeMetrics.ts`):
  - Defines `NormalizedMetrics` interface with three canonical fields: `views`, `engagement_rate`, and `watch_time_seconds`
  - Implements platform-specific normalisation functions for YouTube, Instagram, and Beehiiv
  - Provides discriminated union type `PlatformRawMetrics` for type-safe platform detection
  - Includes comprehensive documentation of platform-specific mappings and edge cases (e.g., clamping engagement_rate to [0, 1], handling division by zero)

- **Updated analytics cron functions** to use normalisation:
  - YouTube: Maps `estimatedMinutesWatched` (minutes) → `watch_time_seconds`, calculates engagement from likes/comments/shares
  - Instagram: Handles Meta's unified `views` metric (Apr 2025 migration), includes saves in engagement calculation, sets `watch_time_seconds` to null
  - Beehiiv: Maps `uniqueOpened` → `views`, converts `openRate` percentage to engagement fraction, sets `watch_time_seconds` to null

- **Type definitions** (`packages/types/src/index.ts`):
  - Exports `NormalizedMetrics` interface for use across packages

- **Public API** (`packages/inngest/src/index.ts`):
  - Exports normalisation function and all platform-specific raw metric types for external use

## Notable Implementation Details

- **Defensive clamping**: `engagement_rate` is always clamped to [0, 1] to handle API anomalies (e.g., bot-inflated interactions)
- **Rounding**: `views` is rounded to nearest integer to normalize floating-point counts from platform APIs
- **Division by zero**: Engagement rate defaults to 0 when views are 0, avoiding NaN results
- **Platform-specific engagement**: Instagram includes saves (strong intent signal); YouTube/Beehiiv do not have this metric
- **Watch time handling**: Only YouTube exposes watch time; Instagram and Beehiiv set this to null

https://claude.ai/code/session_01RuLcQWasZvugjM9T7eFJSg