### PR TITLE
Add Claude-powered narrative generation for pattern insights

### DIFF
--- a/packages/inngest/package.json
+++ b/packages/inngest/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.55.0",
     "@meridian/api": "workspace:*",
     "@meridian/types": "workspace:*",
     "@supabase/supabase-js": "^2.0.0"

--- a/packages/inngest/src/functions/weekly-stats-cron.ts
+++ b/packages/inngest/src/functions/weekly-stats-cron.ts
@@ -1,5 +1,9 @@
 import { inngest } from "../client";
 import { getSupabaseAdmin } from "../lib/supabaseAdmin";
+import {
+  narratePatternInsights,
+  type PatternNarration,
+} from "../lib/narratePatternInsights";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -42,6 +46,8 @@ interface PatternInsightRecord {
   summary: string;
   evidence_json: Record<string, unknown>;
   confidence: number;
+  narrative: string | null;
+  confidence_label: PatternNarration["confidence_label"] | null;
 }
 
 // ─── Statistics helpers ───────────────────────────────────────────────────────
@@ -364,6 +370,8 @@ export const computeCreatorPatterns = inngest.createFunction(
               computed_at: now,
             },
             confidence: confidenceFromCount(best.sample_count),
+            narrative: null,
+            confidence_label: null,
           });
         }
       }
@@ -408,6 +416,8 @@ export const computeCreatorPatterns = inngest.createFunction(
               computed_at: now,
             },
             confidence: confidenceFromCount(best.sample_count),
+            narrative: null,
+            confidence_label: null,
           });
         }
       }
@@ -458,6 +468,8 @@ export const computeCreatorPatterns = inngest.createFunction(
               computed_at: now,
             },
             confidence: confidenceFromCount(best.sample_count),
+            narrative: null,
+            confidence_label: null,
           });
         }
       }
@@ -524,6 +536,8 @@ export const computeCreatorPatterns = inngest.createFunction(
               computed_at: now,
             },
             confidence: confidenceFromCount(weeks.length),
+            narrative: null,
+            confidence_label: null,
           });
         }
       }
@@ -539,10 +553,38 @@ export const computeCreatorPatterns = inngest.createFunction(
       };
     }
 
-    // ── Step 3: replace stale insights, insert fresh ones ─────────────────────
+    // ── Step 3: narrate each statistical pattern via Claude ────────────────────
+    //
+    // Calls claude-opus-4-6 once per insight to produce a 2–3 sentence plain-
+    // English narrative that creators can read instead of raw statistics.
+    // Individual failures are caught inside narratePatternInsights() so the
+    // record simply omits that key; the statistical `summary` is the fallback.
+    const narrations = await step.run(
+      "narrate-pattern-insights",
+      async () => {
+        return narratePatternInsights(
+          insights.map(({ insight_type, summary, evidence_json, confidence }) => ({
+            insight_type,
+            summary,
+            evidence_json,
+            confidence,
+          }))
+        );
+      }
+    );
+
+    // Merge narrations back into the insight records.
+    const narratedInsights = insights.map((insight) => ({
+      ...insight,
+      narrative: narrations[insight.insight_type]?.narrative ?? null,
+      confidence_label:
+        narrations[insight.insight_type]?.confidence_label ?? null,
+    }));
+
+    // ── Step 4: replace stale insights, insert fresh ones ─────────────────────
     await step.run("write-pattern-insights", async () => {
       const supabase = getSupabaseAdmin();
-      const insightTypes = insights.map((i) => i.insight_type);
+      const insightTypes = narratedInsights.map((i) => i.insight_type);
 
       // Delete non-dismissed insights for the same creator + type so that
       // each weekly run produces exactly one fresh row per dimension.
@@ -559,10 +601,12 @@ export const computeCreatorPatterns = inngest.createFunction(
         );
       }
 
-      const rows = insights.map((insight) => ({
+      const rows = narratedInsights.map((insight) => ({
         creator_id,
         insight_type: insight.insight_type,
         summary: insight.summary,
+        narrative: insight.narrative,
+        confidence_label: insight.confidence_label,
         evidence_json: insight.evidence_json,
         confidence: insight.confidence,
         generated_at: new Date().toISOString(),
@@ -583,8 +627,9 @@ export const computeCreatorPatterns = inngest.createFunction(
 
     return {
       creator_id,
-      insightsWritten: insights.length,
-      insightTypes: insights.map((i) => i.insight_type),
+      insightsWritten: narratedInsights.length,
+      insightTypes: narratedInsights.map((i) => i.insight_type),
+      narratedCount: narratedInsights.filter((i) => i.narrative !== null).length,
     };
   }
 );

--- a/packages/inngest/src/lib/narratePatternInsights.ts
+++ b/packages/inngest/src/lib/narratePatternInsights.ts
@@ -1,0 +1,116 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ConfidenceLabel = "Strong" | "Moderate" | "Emerging";
+
+export interface PatternNarration {
+  narrative: string;
+  confidence_label: ConfidenceLabel;
+}
+
+/** Input shape passed from the pattern computation step. */
+export interface PatternInsightInput {
+  insight_type: string;
+  summary: string;
+  evidence_json: Record<string, unknown>;
+  confidence: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Maps a numeric confidence score (0–1) to a human-readable label.
+ *
+ *  Strong   ≥ 0.700  (21+ samples out of the 30-sample target)
+ *  Moderate ≥ 0.400  (12+ samples)
+ *  Emerging <  0.400  (fewer than 12 samples)
+ */
+export function confidenceLabel(score: number): ConfidenceLabel {
+  if (score >= 0.7) return "Strong";
+  if (score >= 0.4) return "Moderate";
+  return "Emerging";
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a creator analytics coach. Given statistical patterns, write 2–3 sentence insight narratives.
+
+Always respond with a single JSON object — no markdown, no prose outside it — in this exact shape:
+{"narrative":"<2-3 sentence actionable insight>","confidence_label":"<Strong|Moderate|Emerging>"}`;
+
+// ─── Main function ────────────────────────────────────────────────────────────
+
+/**
+ * Calls the Claude API to narrate each computed pattern insight as plain
+ * English. Returns a `Record<insight_type, PatternNarration>` suitable for
+ * JSON serialisation in an Inngest step result.
+ *
+ * Each API call uses claude-opus-4-6 with a system prompt that constrains the
+ * response to a strict JSON object containing:
+ *  • narrative        — 2–3 sentence plain-English insight for the creator
+ *  • confidence_label — "Strong" | "Moderate" | "Emerging"
+ *
+ * Failures for individual insights are caught and logged; the returned record
+ * simply omits that key, so callers can fall back to the statistical summary.
+ */
+export async function narratePatternInsights(
+  insights: readonly PatternInsightInput[]
+): Promise<Record<string, PatternNarration>> {
+  const client = new Anthropic();
+  const results: Record<string, PatternNarration> = {};
+
+  for (const insight of insights) {
+    const label = confidenceLabel(insight.confidence);
+
+    const userContent = JSON.stringify({
+      insight_type: insight.insight_type,
+      statistical_summary: insight.summary,
+      evidence: insight.evidence_json,
+      confidence_score: insight.confidence,
+      confidence_label: label,
+    });
+
+    try {
+      const response = await client.messages.create({
+        model: "claude-opus-4-6",
+        max_tokens: 512,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userContent }],
+      });
+
+      const textBlock = response.content.find((b) => b.type === "text");
+      if (!textBlock || textBlock.type !== "text") {
+        throw new Error("Claude response contained no text block");
+      }
+
+      // Extract JSON from the response (strip any accidental surrounding whitespace).
+      const jsonMatch = textBlock.text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new Error(
+          `Claude did not return valid JSON for insight "${insight.insight_type}": ${textBlock.text}`
+        );
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as {
+        narrative: string;
+        confidence_label: ConfidenceLabel;
+      };
+
+      results[insight.insight_type] = {
+        narrative: parsed.narrative,
+        // Always use the deterministic label computed from sample count;
+        // the model's label is advisory only.
+        confidence_label: label,
+      };
+    } catch (err) {
+      // Non-fatal: the statistical summary in `summary` serves as a fallback.
+      console.error(
+        `[narratePatternInsights] Failed to narrate "${insight.insight_type}":`,
+        err
+      );
+    }
+  }
+
+  return results;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -90,6 +90,8 @@ export interface PerformanceSnapshot {
   created_at: string;
 }
 
+export type PatternConfidenceLabel = "Strong" | "Moderate" | "Emerging";
+
 export interface PatternInsight {
   id: string;
   creator_id: string;
@@ -98,6 +100,10 @@ export interface PatternInsight {
   description: string;
   confidence_score: number;
   supporting_content_ids: string[];
+  /** Claude-generated 2–3 sentence plain-English insight. Null if narration failed. */
+  narrative: string | null;
+  /** Human-readable confidence tier derived from sample count. Null if narration failed. */
+  confidence_label: PatternConfidenceLabel | null;
   created_at: string;
   updated_at: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
 
   packages/inngest:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.55.0
+        version: 0.55.1
       '@meridian/api':
         specifier: workspace:*
         version: link:../api
@@ -213,6 +216,10 @@ packages:
     peerDependenciesMeta:
       graphql:
         optional: true
+
+  '@anthropic-ai/sdk@0.55.1':
+    resolution: {integrity: sha512-gjOMS4chmm8BxClKmCjNHmvf1FrO1Cn++CSX6K3YCZjz5JG4I9ZttQ/xEH4FBsz6HQyZvnUpiKlOAkmxaGmEaQ==}
+    hasBin: true
 
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -5341,6 +5348,8 @@ packages:
 snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
+
+  '@anthropic-ai/sdk@0.55.1': {}
 
   '@babel/code-frame@7.10.4':
     dependencies:

--- a/supabase/migrations/20260305000000_add_narrative_to_pattern_insights.sql
+++ b/supabase/migrations/20260305000000_add_narrative_to_pattern_insights.sql
@@ -1,0 +1,13 @@
+-- ===========================================================================
+-- Add Claude-generated narrative fields to pattern_insights
+--
+-- narrative        — 2–3 sentence plain-English insight written by Claude.
+--                   NULL when the API call failed; fall back to `summary`.
+-- confidence_label — Human-readable tier derived from confidence score:
+--                   'Strong' (≥0.700), 'Moderate' (≥0.400), 'Emerging' (<0.400)
+-- ===========================================================================
+
+alter table pattern_insights
+  add column if not exists narrative        text,
+  add column if not exists confidence_label text
+    check (confidence_label in ('Strong', 'Moderate', 'Emerging'));


### PR DESCRIPTION
## Summary
This PR adds AI-powered narrative generation to pattern insights by integrating Claude API calls into the weekly stats computation pipeline. Each computed pattern insight now receives a 2–3 sentence plain-English narrative alongside its statistical summary, making insights more accessible to creators.

## Key Changes

- **New module `narratePatternInsights.ts`**: Implements Claude API integration with:
  - `narratePatternInsights()` function that calls claude-opus-4-6 for each insight
  - `confidenceLabel()` helper that maps numeric confidence scores (0–1) to human-readable tiers: "Strong" (≥0.7), "Moderate" (≥0.4), "Emerging" (<0.4)
  - Strict JSON response parsing with graceful error handling per insight
  - Type definitions for `PatternNarration` and `PatternInsightInput`

- **Updated `weekly-stats-cron.ts`**: 
  - Integrated narration as a new Inngest step ("narrate-pattern-insights") after pattern computation
  - Merges Claude-generated narratives back into insight records before database write
  - Added `narrative` and `confidence_label` fields to `PatternInsightRecord` interface
  - Updated all pattern creation sites to initialize these fields as `null` before narration
  - Added `narratedCount` to function output for observability

- **Database migration**: Added two nullable columns to `pattern_insights` table:
  - `narrative` (text): Stores the Claude-generated insight
  - `confidence_label` (text): Stores the confidence tier with CHECK constraint

- **Type updates**: Extended `PatternInsight` interface in `@meridian/types` with:
  - `narrative: string | null`
  - `confidence_label: PatternConfidenceLabel | null`
  - Added `PatternConfidenceLabel` type export

- **Dependencies**: Added `@anthropic-ai/sdk` (^0.55.0) to inngest package

## Implementation Details

- **Resilience**: Individual narration failures are caught and logged; the insight record omits that key, allowing callers to fall back to the statistical `summary`
- **Deterministic confidence labels**: The function always uses the computed label (from sample count) rather than the model's advisory label, ensuring consistency
- **Strict response format**: System prompt constrains Claude to return only a JSON object with no surrounding prose
- **Batch processing**: All insights for a creator are narrated in sequence within a single Inngest step

https://claude.ai/code/session_01Wb12RqvRiCo8986UG7b8Xd