### PR TITLE
Add insight dismissal functionality to dashboard

### DIFF
--- a/apps/web/app/InsightsPanel.tsx
+++ b/apps/web/app/InsightsPanel.tsx
@@ -26,6 +26,7 @@ export interface DashboardInsight {
   confidence_label: string | null;
   confidence: number;
   generated_at: string;
+  dismissed_at: string | null;
   evidence_json: Record<string, unknown>;
   supporting_content: InsightEvidenceItem[];
 }
@@ -33,6 +34,7 @@ export interface DashboardInsight {
 interface InsightsPanelProps {
   insights: DashboardInsight[];
   content?: ContentItem[];
+  onDismissInsight?: (insightId: string) => Promise<void>;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -67,11 +69,15 @@ function dataWindowLabel(insight: DashboardInsight): string {
 function InsightCard({
   insight,
   animationDelay,
+  onDismiss,
 }: {
   insight: DashboardInsight;
   animationDelay: number;
+  onDismiss?: (insightId: string) => Promise<void>;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [isDismissing, setIsDismissing] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
 
   const meta = INSIGHT_META[insight.insight_type] ?? {
     icon: "💡",
@@ -80,6 +86,23 @@ function InsightCard({
   const confidenceBadge = insight.confidence_label
     ? CONFIDENCE_BADGE[insight.confidence_label]
     : null;
+
+  const handleDismiss = async () => {
+    if (!onDismiss) return;
+    setIsDismissing(true);
+    try {
+      await onDismiss(insight.id);
+      // Trigger removal animation
+      setIsRemoving(true);
+    } catch (error) {
+      console.error("Failed to dismiss insight:", error);
+      setIsDismissing(false);
+    }
+  };
+
+  if (isRemoving) {
+    return null;
+  }
 
   return (
     <div
@@ -114,21 +137,62 @@ function InsightCard({
           >
             {meta.label}
           </span>
-          {confidenceBadge && (
-            <span
-              style={{
-                marginLeft: "auto",
-                fontSize: 11,
-                fontWeight: 700,
-                padding: "2px 8px",
-                borderRadius: 99,
-                background: confidenceBadge.bg,
-                color: confidenceBadge.color,
-              }}
-            >
-              {insight.confidence_label}
-            </span>
-          )}
+          <div style={{ marginLeft: "auto", display: "flex", gap: 8, alignItems: "center" }}>
+            {confidenceBadge && (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: "2px 8px",
+                  borderRadius: 99,
+                  background: confidenceBadge.bg,
+                  color: confidenceBadge.color,
+                }}
+              >
+                {insight.confidence_label}
+              </span>
+            )}
+            {onDismiss && (
+              <button
+                onClick={handleDismiss}
+                disabled={isDismissing}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 24,
+                  height: 24,
+                  padding: 0,
+                  background: "transparent",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 4,
+                  cursor: isDismissing ? "not-allowed" : "pointer",
+                  color: "#9ca3af",
+                  fontSize: 14,
+                  lineHeight: 1,
+                  transition: "all 0.2s",
+                  opacity: isDismissing ? 0.5 : 1,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isDismissing) {
+                    (e.currentTarget as HTMLButtonElement).style.background = "#f3f4f6";
+                    (e.currentTarget as HTMLButtonElement).style.color = "#6b7280";
+                    (e.currentTarget as HTMLButtonElement).style.borderColor = "#d1d5db";
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isDismissing) {
+                    (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+                    (e.currentTarget as HTMLButtonElement).style.color = "#9ca3af";
+                    (e.currentTarget as HTMLButtonElement).style.borderColor = "#e5e7eb";
+                  }
+                }}
+                title="Dismiss this insight"
+              >
+                ✕
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Headline */}
@@ -322,6 +386,7 @@ function InsightCard({
 export default function InsightsPanel({
   insights,
   content = [],
+  onDismissInsight,
 }: InsightsPanelProps) {
   // Check if content has less than 30 days of data
   const thresholdInfo = useMemo(
@@ -361,6 +426,7 @@ export default function InsightsPanel({
             key={insight.id}
             insight={insight}
             animationDelay={i * 80}
+            onDismiss={onDismissInsight}
           />
         ))}
       </div>

--- a/apps/web/app/InsightsPanelClient.tsx
+++ b/apps/web/app/InsightsPanelClient.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import InsightsPanel from "./InsightsPanel";
+import type { DashboardInsight } from "./InsightsPanel";
+import type { ContentItem } from "@/lib/dataThreshold";
+
+interface InsightsPanelClientProps {
+  insights: DashboardInsight[];
+  content?: ContentItem[];
+}
+
+export default function InsightsPanelClient({
+  insights: initialInsights,
+  content,
+}: InsightsPanelClientProps) {
+  const [insights, setInsights] = useState(initialInsights);
+
+  const handleDismissInsight = async (insightId: string) => {
+    try {
+      const response = await fetch("/api/insights/dismiss", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ insight_id: insightId }),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to dismiss insight: ${response.status} ${response.statusText}`
+        );
+      }
+
+      // Remove the insight from the UI
+      setInsights((prev) => prev.filter((insight) => insight.id !== insightId));
+    } catch (error) {
+      console.error("Failed to dismiss insight:", error);
+      throw error;
+    }
+  };
+
+  return (
+    <InsightsPanel
+      insights={insights}
+      content={content}
+      onDismissInsight={handleDismissInsight}
+    />
+  );
+}

--- a/apps/web/app/api/insights/dismiss/route.ts
+++ b/apps/web/app/api/insights/dismiss/route.ts
@@ -1,0 +1,100 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+
+/**
+ * POST /api/insights/dismiss
+ *
+ * Dismisses (archives) an insight by marking it with dismissed_at timestamp.
+ * Dismissed insights are excluded from the dashboard display but are retained
+ * in the database for historical tracking.
+ *
+ * Request body:
+ *   {
+ *     insight_id: string (UUID)
+ *   }
+ *
+ * Response:
+ *   200 { dismissed: true }
+ *   400 Bad request (missing insight_id)
+ *   401 Unauthorized (not logged in)
+ *   404 Not found (insight doesn't exist or doesn't belong to creator)
+ *   500 Server error
+ */
+
+export async function POST(request: NextRequest) {
+  // ── 1. Parse request body ──────────────────────────────────────────────────
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON request body" },
+      { status: 400 }
+    );
+  }
+
+  const { insight_id } = body as { insight_id?: string };
+
+  if (!insight_id || typeof insight_id !== "string") {
+    return NextResponse.json(
+      { error: "Missing or invalid insight_id" },
+      { status: 400 }
+    );
+  }
+
+  // ── 2. Verify authenticated creator ────────────────────────────────────────
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // ── 3. Look up the creator ─────────────────────────────────────────────────
+  const { data: creator, error: creatorErr } = await supabase
+    .from("creators")
+    .select("id")
+    .eq("auth_user_id", user.id)
+    .single();
+
+  if (creatorErr || !creator) {
+    return NextResponse.json(
+      { error: "Creator not found" },
+      { status: 401 }
+    );
+  }
+
+  // ── 4. Verify the insight belongs to this creator ──────────────────────────
+  const { data: insight, error: selectErr } = await supabase
+    .from("pattern_insights")
+    .select("id")
+    .eq("id", insight_id)
+    .eq("creator_id", creator.id)
+    .single();
+
+  if (selectErr || !insight) {
+    return NextResponse.json(
+      { error: "Insight not found" },
+      { status: 404 }
+    );
+  }
+
+  // ── 5. Mark the insight as dismissed ───────────────────────────────────────
+  const { error: updateErr } = await supabase
+    .from("pattern_insights")
+    .update({ dismissed_at: new Date().toISOString(), is_dismissed: true })
+    .eq("id", insight_id)
+    .eq("creator_id", creator.id);
+
+  if (updateErr) {
+    console.error("[insights/dismiss] Update failed:", updateErr.message);
+    return NextResponse.json(
+      { error: "Failed to dismiss insight" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ dismissed: true }, { status: 200 });
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { createServerClient } from "@/lib/supabase/server";
 import CreatorDashboard from "./CreatorDashboard";
 import type { DashboardProps } from "./CreatorDashboard";
-import InsightsPanel from "./InsightsPanel";
+import InsightsPanelClient from "./InsightsPanelClient";
 import type { DashboardInsight, InsightEvidenceItem } from "./InsightsPanel";
 
 /**
@@ -71,7 +71,7 @@ export default async function Home() {
         supabase
           .from("pattern_insights")
           .select(
-            "id, insight_type, summary, narrative, confidence_label, confidence, generated_at, evidence_json",
+            "id, insight_type, summary, narrative, confidence_label, confidence, generated_at, dismissed_at, evidence_json",
           )
           .eq("creator_id", creator.id)
           .eq("is_dismissed", false)
@@ -141,6 +141,7 @@ export default async function Home() {
             confidence_label: row.confidence_label as string | null,
             confidence: row.confidence as number,
             generated_at: row.generated_at as string,
+            dismissed_at: row.dismissed_at as string | null,
             evidence_json: evidence,
             supporting_content: supporting,
           };
@@ -155,6 +156,7 @@ export default async function Home() {
           confidence_label: row.confidence_label as string | null,
           confidence: row.confidence as number,
           generated_at: row.generated_at as string,
+          dismissed_at: row.dismissed_at as string | null,
           evidence_json: (row.evidence_json ?? {}) as Record<string, unknown>,
           supporting_content: [],
         }));
@@ -247,7 +249,7 @@ export default async function Home() {
         </p>
       </div>
 
-      <InsightsPanel
+      <InsightsPanelClient
         insights={dashboardInsights}
         content={dashboardContent.map(({ publishedAt }) => ({ publishedAt }))}
       />

--- a/supabase/migrations/20260305000002_add_dismissed_at_to_pattern_insights.sql
+++ b/supabase/migrations/20260305000002_add_dismissed_at_to_pattern_insights.sql
@@ -1,0 +1,12 @@
+-- ===========================================================================
+-- Add dismissed_at timestamp to pattern_insights
+--
+-- dismissed_at — Timestamp when the insight was dismissed by the creator.
+--               NULL when not dismissed.
+-- ===========================================================================
+
+alter table pattern_insights
+  add column if not exists dismissed_at timestamptz;
+
+-- Create index for filtering active (non-dismissed) insights
+create index if not exists idx_pattern_insights_dismissed_at on pattern_insights (dismissed_at);


### PR DESCRIPTION
## Summary
This PR adds the ability for users to dismiss insights from the dashboard. Dismissed insights are marked with a timestamp and hidden from view, while being retained in the database for historical tracking.

## Key Changes

- **New API endpoint** (`POST /api/insights/dismiss`): Handles dismissing insights by marking them with a `dismissed_at` timestamp. Includes authentication checks and ownership validation to ensure users can only dismiss their own insights.

- **Database migration**: Adds `dismissed_at` timestamptz column to `pattern_insights` table with an index for efficient filtering of active (non-dismissed) insights.

- **UI dismiss button**: Added a close button (✕) to each insight card in the header that triggers the dismiss action. The button includes hover states and disabled state during the API call.

- **Client-side state management**: Created new `InsightsPanelClient` component to handle the client-side logic for dismissing insights, including optimistic UI updates that remove dismissed insights from the list.

- **Updated data fetching**: Modified the dashboard query to include the `dismissed_at` field and filter out insights where `is_dismissed` is true, ensuring dismissed insights don't appear on page load.

- **Type updates**: Extended `DashboardInsight` interface to include the `dismissed_at` field and added `onDismissInsight` callback prop to `InsightsPanel`.

## Implementation Details

- The dismiss endpoint validates that the insight belongs to the authenticated user's creator account before allowing dismissal
- Dismissed insights are removed from the UI immediately after successful API response (optimistic update)
- The dismiss button is only rendered when the `onDismissInsight` callback is provided, maintaining backward compatibility
- Error handling includes proper HTTP status codes (400 for bad requests, 401 for unauthorized, 404 for not found, 500 for server errors)

https://claude.ai/code/session_01KcsoVVHsjLZLUCvMX4K6F3