### PR TITLE
Inject creator pattern insights into derivative generation prompts

### DIFF
--- a/packages/inngest/src/functions/generate-derivatives.ts
+++ b/packages/inngest/src/functions/generate-derivatives.ts
@@ -2,6 +2,10 @@ import Anthropic from "@anthropic-ai/sdk";
 import { inngest } from "../client";
 import { getSupabaseAdmin } from "../lib/supabaseAdmin";
 import { DERIVATIVE_FORMATS, type DerivativeFormat } from "../lib/derivative-prompts";
+import {
+  fetchTopCreatorInsights,
+  buildInsightContext,
+} from "../lib/fetchCreatorInsights";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -22,15 +26,20 @@ async function generateSingleDerivative(
   transcript: string,
   contentTitle: string,
   format: DerivativeFormat,
+  insightContext: string,
 ): Promise<{ content: string; char_count: number }> {
   const anthropic = new Anthropic({
     apiKey: process.env.ANTHROPIC_API_KEY!,
   });
 
+  const systemPrompt = insightContext
+    ? `${format.systemPrompt}${insightContext}`
+    : format.systemPrompt;
+
   const message = await anthropic.messages.create({
     model: "claude-sonnet-4-20250514",
     max_tokens: 2000,
-    system: format.systemPrompt,
+    system: systemPrompt,
     messages: [
       {
         role: "user",
@@ -57,8 +66,9 @@ async function generateSingleDerivative(
  *
  * Steps:
  *  1. load-job – Load the repurpose job and verify transcript exists
- *  2. generate-{format} – One step per selected format, calling Claude API
- *  3. save-derivatives – Persist all generated derivatives to the job
+ *  2. fetch-creator-insights – Load top 2 pattern insights for the creator
+ *  3. generate-{format} – One step per selected format, calling Claude API
+ *  4. save-derivatives – Persist all generated derivatives to the job
  */
 export const generateDerivatives = inngest.createFunction(
   {
@@ -121,12 +131,18 @@ export const generateDerivatives = inngest.createFunction(
 
     const { transcript, selectedFormats, contentTitle } = jobData;
 
+    // ── Step 2: Fetch creator pattern insights ───────────────────────────────
+    const insightContext = await step.run("fetch-creator-insights", async () => {
+      const insights = await fetchTopCreatorInsights(creator_id);
+      return buildInsightContext(insights);
+    });
+
     // Determine which formats to generate
     const formatsToGenerate = selectedFormats.length > 0
       ? selectedFormats.filter((f) => DERIVATIVE_FORMATS[f])
       : Object.keys(DERIVATIVE_FORMATS);
 
-    // ── Step 2: Generate each derivative ─────────────────────────────────────
+    // ── Step 3: Generate each derivative ─────────────────────────────────────
     const derivatives: Derivative[] = [];
     const now = new Date().toISOString();
 
@@ -134,7 +150,7 @@ export const generateDerivatives = inngest.createFunction(
       const format = DERIVATIVE_FORMATS[formatKey]!;
 
       const result = await step.run(`generate-${formatKey}`, async () => {
-        return generateSingleDerivative(transcript, contentTitle, format);
+        return generateSingleDerivative(transcript, contentTitle, format, insightContext);
       });
 
       derivatives.push({
@@ -149,7 +165,7 @@ export const generateDerivatives = inngest.createFunction(
       });
     }
 
-    // ── Step 3: Save derivatives and mark job as ready for review ─────────
+    // ── Step 4: Save derivatives and mark job as ready for review ─────────
     await step.run("save-derivatives", async () => {
       const supabase = getSupabaseAdmin();
 
@@ -199,7 +215,7 @@ export const regenerateDerivative = inngest.createFunction(
 
       const { data: job, error } = await supabase
         .from("repurpose_jobs")
-        .select("id, source_item_id, source_transcript, derivatives")
+        .select("id, creator_id, source_item_id, source_transcript, derivatives")
         .eq("id", repurpose_job_id)
         .single();
 
@@ -214,6 +230,7 @@ export const regenerateDerivative = inngest.createFunction(
         .single();
 
       return {
+        creatorId: job.creator_id as string,
         transcript: job.source_transcript ?? "",
         derivatives: (job.derivatives ?? []) as Derivative[],
         contentTitle: contentItem?.title ?? "Untitled",
@@ -225,11 +242,18 @@ export const regenerateDerivative = inngest.createFunction(
       throw new Error(`Unknown format: ${format_key}`);
     }
 
+    // ── Fetch creator pattern insights ───────────────────────────────────────
+    const insightContext = await step.run("fetch-creator-insights", async () => {
+      const insights = await fetchTopCreatorInsights(jobData.creatorId);
+      return buildInsightContext(insights);
+    });
+
     const result = await step.run("regenerate", async () => {
       return generateSingleDerivative(
         jobData.transcript,
         jobData.contentTitle,
         format,
+        insightContext,
       );
     });
 

--- a/packages/inngest/src/lib/fetchCreatorInsights.ts
+++ b/packages/inngest/src/lib/fetchCreatorInsights.ts
@@ -1,0 +1,58 @@
+import { getSupabaseAdmin } from "./supabaseAdmin";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface CreatorInsightContext {
+  insight_type: string;
+  narrative: string | null;
+  summary: string;
+  confidence_label: string | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the top N non-dismissed pattern insights for a creator,
+ * ordered by confidence (desc) then recency (desc).
+ *
+ * Returns an empty array on any error so callers can degrade gracefully —
+ * a missing insight should never block derivative generation.
+ */
+export async function fetchTopCreatorInsights(
+  creatorId: string,
+  limit = 2,
+): Promise<CreatorInsightContext[]> {
+  const supabase = getSupabaseAdmin();
+
+  const { data, error } = await supabase
+    .from("pattern_insights")
+    .select("insight_type, narrative, summary, confidence_label")
+    .eq("creator_id", creatorId)
+    .eq("is_dismissed", false)
+    .order("confidence", { ascending: false })
+    .order("generated_at", { ascending: false })
+    .limit(limit);
+
+  if (error || !data) {
+    return [];
+  }
+
+  return data as CreatorInsightContext[];
+}
+
+/**
+ * Builds the pattern-aware context block to inject into a system prompt.
+ *
+ * Uses the Claude-narrated `narrative` when available, falling back to the
+ * raw statistical `summary`. Returns an empty string when there are no
+ * insights so callers can safely concatenate without adding blank lines.
+ */
+export function buildInsightContext(insights: CreatorInsightContext[]): string {
+  if (insights.length === 0) return "";
+
+  const bullets = insights
+    .map((i) => `- ${i.narrative ?? i.summary}`)
+    .join("\n");
+
+  return `\nThis creator's data shows their audience responds best to:\n${bullets}\n`;
+}


### PR DESCRIPTION
## Summary
This PR enhances the derivative generation pipeline by incorporating creator pattern insights into Claude's system prompts. The system now fetches the top 2 pattern insights for each creator and injects them as context, allowing the AI to generate more personalized and audience-aligned content.

## Key Changes
- **New module** `fetchCreatorInsights.ts`: Provides utilities to fetch non-dismissed pattern insights from the database and format them for prompt injection
  - `fetchTopCreatorInsights()`: Queries the `pattern_insights` table ordered by confidence and recency, with graceful error handling
  - `buildInsightContext()`: Converts insights into a formatted context block for system prompts, preferring Claude-narrated narratives over raw summaries
  
- **Updated `generate-derivatives.ts`**: Integrated insight fetching into both generation workflows
  - Added "fetch-creator-insights" step to load creator insights before generating derivatives
  - Modified `generateSingleDerivative()` to accept and inject `insightContext` into the system prompt
  - Updated both `generateDerivatives` and `regenerateDerivative` functions to fetch and pass insight context
  - Ensured `regenerateDerivative` now retrieves `creator_id` from the job record

## Implementation Details
- Insights are fetched once per job and reused across all format generations for efficiency
- Empty insight context returns an empty string, allowing safe concatenation without adding blank lines
- Database errors gracefully degrade to empty insights, ensuring generation never blocks on missing data
- The insight context is appended to the existing format system prompt, providing audience-response guidance without replacing core instructions

https://claude.ai/code/session_01BpXZPWRBD3k77jmuHhPf2C