### PR TITLE
Add text import feature for repurposing pasted content

### DIFF
--- a/apps/web/app/api/repurpose/text-import/route.ts
+++ b/apps/web/app/api/repurpose/text-import/route.ts
@@ -1,0 +1,157 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { inngest } from "@meridian/inngest";
+import { createServerClient } from "@/lib/supabase/server";
+
+const VALID_PLATFORMS = new Set([
+  "youtube",
+  "instagram",
+  "tiktok",
+  "twitter",
+  "linkedin",
+  "facebook",
+  "podcast",
+  "other",
+]);
+
+/**
+ * POST /api/repurpose/text-import
+ *
+ * Creates a content_item (content_type=text_import, no platform) from
+ * pasted text and immediately creates a repurpose_job for it.
+ *
+ * Request body:
+ *   {
+ *     title: string              – human-readable title for the piece
+ *     body: string               – the full text to repurpose
+ *     target_platform: string    – intended output platform
+ *     selected_formats?: string[] – derivative formats (all if omitted)
+ *   }
+ *
+ * Response:
+ *   201 { job_id: string, content_item_id: string }
+ *   400 Bad request
+ *   401 Unauthorized
+ *   500 Server error
+ */
+export async function POST(request: NextRequest) {
+  // ── 1. Parse request body ──────────────────────────────────────────────────
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON request body" },
+      { status: 400 }
+    );
+  }
+
+  const { title, body: text, target_platform, selected_formats } = body as {
+    title?: string;
+    body?: string;
+    target_platform?: string;
+    selected_formats?: string[];
+  };
+
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Missing or invalid title" },
+      { status: 400 }
+    );
+  }
+
+  if (!text || typeof text !== "string" || text.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Missing or invalid body text" },
+      { status: 400 }
+    );
+  }
+
+  if (!target_platform || !VALID_PLATFORMS.has(target_platform)) {
+    return NextResponse.json(
+      { error: "Missing or invalid target_platform" },
+      { status: 400 }
+    );
+  }
+
+  // ── 2. Verify authenticated creator ────────────────────────────────────────
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: creator, error: creatorErr } = await supabase
+    .from("creators")
+    .select("id")
+    .eq("auth_user_id", user.id)
+    .single();
+
+  if (creatorErr || !creator) {
+    return NextResponse.json({ error: "Creator not found" }, { status: 401 });
+  }
+
+  // ── 3. Create content_item for the pasted text ─────────────────────────────
+  const { data: contentItem, error: contentErr } = await supabase
+    .from("content_items")
+    .insert({
+      creator_id: creator.id,
+      title: title.trim(),
+      body: text.trim(),
+      content_type: "text_import",
+      // platform intentionally null – this is not from a connected platform
+      published_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (contentErr || !contentItem) {
+    console.error("[text-import] Failed to create content_item:", contentErr?.message);
+    return NextResponse.json(
+      { error: "Failed to create content item" },
+      { status: 500 }
+    );
+  }
+
+  // ── 4. Create the repurpose job ────────────────────────────────────────────
+  const { data: job, error: jobErr } = await supabase
+    .from("repurpose_jobs")
+    .insert({
+      creator_id: creator.id,
+      source_item_id: contentItem.id,
+      target_platform,
+      status: "pending",
+      selected_formats: selected_formats ?? [],
+    })
+    .select("id")
+    .single();
+
+  if (jobErr || !job) {
+    console.error("[text-import] Failed to create repurpose_job:", jobErr?.message);
+    return NextResponse.json(
+      { error: "Failed to create repurpose job" },
+      { status: 500 }
+    );
+  }
+
+  // ── 5. Fire repurpose/job.created – pipeline will use body as transcript ───
+  try {
+    await inngest.send({
+      name: "repurpose/job.created",
+      data: {
+        creator_id: creator.id,
+        repurpose_job_id: job.id,
+      },
+    });
+  } catch (err) {
+    console.error("[text-import] inngest.send failed:", err);
+    // Non-fatal: job row exists, pipeline can be retried
+  }
+
+  return NextResponse.json(
+    { job_id: job.id, content_item_id: contentItem.id },
+    { status: 201 }
+  );
+}

--- a/apps/web/app/repurpose/new/page.tsx
+++ b/apps/web/app/repurpose/new/page.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState } from "react";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ALL_PLATFORMS: { value: string; label: string }[] = [
+  { value: "twitter", label: "Twitter / X" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "instagram", label: "Instagram" },
+  { value: "tiktok", label: "TikTok" },
+  { value: "youtube", label: "YouTube" },
+  { value: "facebook", label: "Facebook" },
+  { value: "podcast", label: "Podcast" },
+  { value: "other", label: "Other" },
+];
+
+const DERIVATIVE_FORMATS: { value: string; label: string }[] = [
+  { value: "twitter_thread", label: "Twitter / X Thread" },
+  { value: "linkedin_post", label: "LinkedIn Post" },
+  { value: "instagram_caption", label: "Instagram Caption" },
+  { value: "newsletter_blurb", label: "Newsletter Blurb" },
+  { value: "tiktok_script", label: "TikTok Script" },
+];
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function NewTextImportPage() {
+  const router = useRouter();
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [selectedPlatform, setSelectedPlatform] = useState("");
+  const [selectedFormats, setSelectedFormats] = useState<Set<string>>(new Set());
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  function toggleFormat(value: string) {
+    setSelectedFormats((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !body.trim() || !selectedPlatform) return;
+
+    setStatus("loading");
+    setErrorMessage("");
+
+    try {
+      const res = await fetch("/api/repurpose/text-import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          target_platform: selectedPlatform,
+          selected_formats: [...selectedFormats],
+        }),
+      });
+
+      const data = (await res.json()) as { job_id?: string; error?: string };
+
+      if (!res.ok) {
+        setErrorMessage(data.error ?? "Something went wrong. Please try again.");
+        setStatus("error");
+        return;
+      }
+
+      router.push(`/repurpose/review?job_id=${data.job_id}`);
+    } catch {
+      setErrorMessage("Network error. Please try again.");
+      setStatus("error");
+    }
+  }
+
+  const canSubmit =
+    title.trim().length > 0 &&
+    body.trim().length > 0 &&
+    selectedPlatform !== "" &&
+    status !== "loading";
+
+  return (
+    <main
+      style={{
+        maxWidth: 680,
+        margin: "64px auto",
+        padding: "0 24px 64px",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      {/* Header */}
+      <div style={{ marginBottom: 32 }}>
+        <Link
+          href="/repurpose"
+          style={{
+            color: "#6b7280",
+            fontSize: 14,
+            textDecoration: "none",
+            display: "inline-block",
+            marginBottom: 8,
+          }}
+        >
+          ← Back to queue
+        </Link>
+        <h1
+          style={{
+            fontSize: 24,
+            fontWeight: 700,
+            margin: "0 0 4px",
+            color: "#111827",
+          }}
+        >
+          Repurpose from text
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: "#6b7280" }}>
+          Paste a newsletter, blog post, or any text to generate derivative
+          content across platforms.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        {/* Title */}
+        <div style={{ marginBottom: 20 }}>
+          <label
+            htmlFor="title"
+            style={{
+              display: "block",
+              fontSize: 13,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 6,
+            }}
+          >
+            Title
+          </label>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. My Weekly Newsletter – Issue #42"
+            maxLength={300}
+            style={{
+              width: "100%",
+              padding: "10px 12px",
+              border: "1.5px solid #e5e7eb",
+              borderRadius: 8,
+              fontSize: 14,
+              color: "#111827",
+              outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Body text */}
+        <div style={{ marginBottom: 24 }}>
+          <label
+            htmlFor="body"
+            style={{
+              display: "block",
+              fontSize: 13,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 6,
+            }}
+          >
+            Content
+            <span
+              style={{ fontWeight: 400, color: "#9ca3af", marginLeft: 4 }}
+            >
+              (paste your newsletter, blog post, or article)
+            </span>
+          </label>
+          <textarea
+            id="body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Paste your text here…"
+            rows={14}
+            style={{
+              width: "100%",
+              padding: "10px 12px",
+              border: "1.5px solid #e5e7eb",
+              borderRadius: 8,
+              fontSize: 14,
+              color: "#111827",
+              lineHeight: 1.6,
+              resize: "vertical",
+              outline: "none",
+              boxSizing: "border-box",
+              fontFamily: "inherit",
+            }}
+          />
+          {body.length > 0 && (
+            <p
+              style={{
+                margin: "4px 0 0",
+                fontSize: 12,
+                color: "#9ca3af",
+                textAlign: "right",
+              }}
+            >
+              {body.length.toLocaleString()} characters
+            </p>
+          )}
+        </div>
+
+        {/* Target platform */}
+        <fieldset
+          style={{ border: "none", padding: 0, margin: "0 0 24px" }}
+        >
+          <legend
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 10,
+              padding: 0,
+            }}
+          >
+            Target platform
+          </legend>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+              gap: 8,
+            }}
+          >
+            {ALL_PLATFORMS.map((p) => {
+              const isSelected = selectedPlatform === p.value;
+              return (
+                <label
+                  key={p.value}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "9px 12px",
+                    borderRadius: 8,
+                    border: `1.5px solid ${isSelected ? "#2563eb" : "#e5e7eb"}`,
+                    background: isSelected ? "#eff6ff" : "#fff",
+                    cursor: "pointer",
+                    fontSize: 13,
+                    fontWeight: isSelected ? 600 : 400,
+                    color: isSelected ? "#1d4ed8" : "#374151",
+                    transition: "border-color 0.1s, background 0.1s",
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="target_platform"
+                    value={p.value}
+                    checked={isSelected}
+                    onChange={() => setSelectedPlatform(p.value)}
+                    style={{ accentColor: "#2563eb" }}
+                  />
+                  {p.label}
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        {/* Derivative formats */}
+        <fieldset
+          style={{ border: "none", padding: 0, margin: "0 0 28px" }}
+        >
+          <legend
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: "#374151",
+              marginBottom: 10,
+              padding: 0,
+            }}
+          >
+            Derivative formats
+            <span
+              style={{ fontWeight: 400, color: "#9ca3af", marginLeft: 4 }}
+            >
+              (optional — all if none selected)
+            </span>
+          </legend>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+              gap: 8,
+            }}
+          >
+            {DERIVATIVE_FORMATS.map((f) => {
+              const isSelected = selectedFormats.has(f.value);
+              return (
+                <label
+                  key={f.value}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "9px 12px",
+                    borderRadius: 8,
+                    border: `1.5px solid ${isSelected ? "#7c3aed" : "#e5e7eb"}`,
+                    background: isSelected ? "#f5f3ff" : "#fff",
+                    cursor: "pointer",
+                    fontSize: 13,
+                    fontWeight: isSelected ? 600 : 400,
+                    color: isSelected ? "#6d28d9" : "#374151",
+                    transition: "border-color 0.1s, background 0.1s",
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleFormat(f.value)}
+                    style={{ accentColor: "#7c3aed" }}
+                  />
+                  {f.label}
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        {/* Error */}
+        {status === "error" && (
+          <p
+            style={{
+              margin: "0 0 16px",
+              fontSize: 13,
+              color: "#dc2626",
+              background: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: 6,
+              padding: "8px 12px",
+            }}
+          >
+            {errorMessage}
+          </p>
+        )}
+
+        {/* Actions */}
+        <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+          <Link
+            href="/repurpose"
+            style={{
+              padding: "9px 20px",
+              borderRadius: 7,
+              border: "1px solid #e5e7eb",
+              background: "#fff",
+              color: "#374151",
+              fontWeight: 500,
+              fontSize: 14,
+              textDecoration: "none",
+              display: "inline-block",
+            }}
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            style={{
+              padding: "9px 20px",
+              borderRadius: 7,
+              border: "none",
+              background: canSubmit ? "#2563eb" : "#93c5fd",
+              color: "#fff",
+              fontWeight: 600,
+              fontSize: 14,
+              cursor: canSubmit ? "pointer" : "not-allowed",
+            }}
+          >
+            {status === "loading" ? "Submitting…" : "Start repurposing"}
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/apps/web/app/repurpose/page.tsx
+++ b/apps/web/app/repurpose/page.tsx
@@ -30,6 +30,14 @@ const STATUS_BADGE: Record<string, { bg: string; color: string; label: string }>
   failed: { bg: "#fee2e2", color: "#991b1b", label: "Failed" },
 };
 
+const FORMAT_LABELS: Record<string, string> = {
+  twitter_thread: "Twitter Thread",
+  linkedin_post: "LinkedIn Post",
+  instagram_caption: "Instagram Caption",
+  newsletter_blurb: "Newsletter Blurb",
+  tiktok_script: "TikTok Script",
+};
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", {
     month: "short",
@@ -37,6 +45,13 @@ function formatDate(iso: string): string {
     hour: "numeric",
     minute: "2-digit",
   });
+}
+
+function formatsList(formats: string[]): string {
+  if (!formats || formats.length === 0) return "All formats";
+  return formats
+    .map((f) => FORMAT_LABELS[f] ?? f)
+    .join(", ");
 }
 
 // ─── Page ────────────────────────────────────────────────────────────────────
@@ -71,26 +86,27 @@ export default async function RepurposeQueuePage() {
 
   // Fetch content item titles
   const sourceIds = [...new Set(allJobs.map((j) => j.source_item_id))];
-  const contentMap: Record<string, { title: string; platform: string }> = {};
+  const contentMap: Record<string, { title: string; platform: string | null; content_type: string | null }> = {};
 
   if (sourceIds.length > 0) {
     const { data: items } = await supabase
       .from("content_items")
-      .select("id, title, platform")
+      .select("id, title, platform, content_type")
       .in("id", sourceIds);
 
     for (const item of items ?? []) {
-      contentMap[item.id] = { title: item.title, platform: item.platform };
+      contentMap[item.id] = {
+        title: item.title,
+        platform: item.platform,
+        content_type: item.content_type,
+      };
     }
   }
-
-  const reviewJobs = allJobs.filter((j) => j.status === "review");
-  const otherJobs = allJobs.filter((j) => j.status !== "review");
 
   return (
     <main
       style={{
-        maxWidth: 900,
+        maxWidth: 960,
         margin: "64px auto",
         padding: "0 24px",
         fontFamily: "system-ui, sans-serif",
@@ -100,9 +116,10 @@ export default async function RepurposeQueuePage() {
       <div
         style={{
           display: "flex",
-          alignItems: "center",
+          alignItems: "flex-start",
           justifyContent: "space-between",
           marginBottom: 32,
+          gap: 16,
         }}
       >
         <div>
@@ -129,89 +146,33 @@ export default async function RepurposeQueuePage() {
             Repurpose Queue
           </h1>
           <p style={{ margin: "4px 0 0", fontSize: 14, color: "#6b7280" }}>
-            Review and approve AI-generated derivatives before publishing.
+            Track all in-progress and completed repurpose jobs.
           </p>
         </div>
+
+        {/* New text import CTA */}
+        <Link
+          href="/repurpose/new"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "9px 16px",
+            borderRadius: 8,
+            background: "#2563eb",
+            color: "#fff",
+            fontWeight: 600,
+            fontSize: 14,
+            textDecoration: "none",
+            flexShrink: 0,
+            marginTop: 28,
+          }}
+        >
+          + Paste text
+        </Link>
       </div>
 
-      {/* Ready for Review section */}
-      {reviewJobs.length > 0 && (
-        <section style={{ marginBottom: 40 }}>
-          <h2
-            style={{
-              fontSize: 16,
-              fontWeight: 700,
-              color: "#111827",
-              margin: "0 0 16px",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-            }}
-          >
-            Ready for Review
-            <span
-              style={{
-                background: "#e0e7ff",
-                color: "#3730a3",
-                borderRadius: 12,
-                padding: "2px 10px",
-                fontSize: 12,
-                fontWeight: 600,
-              }}
-            >
-              {reviewJobs.length}
-            </span>
-          </h2>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 10,
-            }}
-          >
-            {reviewJobs.map((job) => (
-              <JobCard
-                key={job.id}
-                job={job}
-                contentInfo={contentMap[job.source_item_id]}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* All Jobs section */}
-      {otherJobs.length > 0 && (
-        <section>
-          <h2
-            style={{
-              fontSize: 16,
-              fontWeight: 700,
-              color: "#111827",
-              margin: "0 0 16px",
-            }}
-          >
-            All Jobs
-          </h2>
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 10,
-            }}
-          >
-            {otherJobs.map((job) => (
-              <JobCard
-                key={job.id}
-                job={job}
-                contentInfo={contentMap[job.source_item_id]}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {allJobs.length === 0 && (
+      {allJobs.length === 0 ? (
         <div
           style={{
             textAlign: "center",
@@ -222,102 +183,183 @@ export default async function RepurposeQueuePage() {
           <p style={{ fontSize: 16, margin: "0 0 8px" }}>
             No repurpose jobs yet.
           </p>
-          <p style={{ fontSize: 14 }}>
-            Start by clicking &quot;Repurpose&quot; on any content item from the dashboard.
+          <p style={{ fontSize: 14, margin: "0 0 20px" }}>
+            Start by pasting text or clicking &quot;Repurpose&quot; on any content item.
           </p>
+          <Link
+            href="/repurpose/new"
+            style={{
+              display: "inline-block",
+              padding: "9px 18px",
+              borderRadius: 8,
+              background: "#2563eb",
+              color: "#fff",
+              fontWeight: 600,
+              fontSize: 14,
+              textDecoration: "none",
+            }}
+          >
+            + Paste text to repurpose
+          </Link>
+        </div>
+      ) : (
+        <div
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 10,
+            overflow: "hidden",
+            background: "#fff",
+          }}
+        >
+          {/* Table header */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 220px 160px 140px 32px",
+              padding: "10px 20px",
+              background: "#f9fafb",
+              borderBottom: "1px solid #e5e7eb",
+              fontSize: 12,
+              fontWeight: 600,
+              color: "#6b7280",
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            <span>Source</span>
+            <span>Formats</span>
+            <span>Status</span>
+            <span>Created</span>
+            <span />
+          </div>
+
+          {/* Table rows */}
+          {allJobs.map((job, idx) => {
+            const contentInfo = contentMap[job.source_item_id];
+            const badge = STATUS_BADGE[job.status] ?? STATUS_BADGE.pending;
+            const derivatives = (job.derivatives ?? []) as Derivative[];
+            const approvedCount = derivatives.filter(
+              (d) => d.status === "approved"
+            ).length;
+            const isLast = idx === allJobs.length - 1;
+
+            return (
+              <Link
+                key={job.id}
+                href={`/repurpose/review?job_id=${job.id}`}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 220px 160px 140px 32px",
+                  padding: "14px 20px",
+                  borderBottom: isLast ? "none" : "1px solid #f3f4f6",
+                  textDecoration: "none",
+                  color: "inherit",
+                  alignItems: "center",
+                  gap: 0,
+                  transition: "background 0.1s",
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLAnchorElement).style.background =
+                    "#f9fafb";
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLAnchorElement).style.background =
+                    "transparent";
+                }}
+              >
+                {/* Source title */}
+                <div style={{ minWidth: 0, paddingRight: 16 }}>
+                  <div
+                    style={{
+                      fontWeight: 600,
+                      fontSize: 14,
+                      color: "#111827",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {contentInfo?.title ?? "Untitled content"}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: "#9ca3af",
+                      marginTop: 2,
+                    }}
+                  >
+                    {contentInfo?.content_type === "text_import"
+                      ? "Text import"
+                      : contentInfo?.platform
+                        ? contentInfo.platform.charAt(0).toUpperCase() +
+                          contentInfo.platform.slice(1)
+                        : "Unknown"}
+                  </div>
+                </div>
+
+                {/* Formats */}
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: "#374151",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    paddingRight: 16,
+                  }}
+                  title={formatsList(job.selected_formats)}
+                >
+                  {formatsList(job.selected_formats)}
+                  {derivatives.length > 0 && approvedCount > 0 && (
+                    <span style={{ color: "#9ca3af", marginLeft: 4 }}>
+                      ({approvedCount}/{derivatives.length} approved)
+                    </span>
+                  )}
+                </div>
+
+                {/* Status badge */}
+                <div>
+                  <span
+                    style={{
+                      background: badge.bg,
+                      color: badge.color,
+                      borderRadius: 6,
+                      padding: "3px 10px",
+                      fontSize: 12,
+                      fontWeight: 600,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {badge.label}
+                  </span>
+                </div>
+
+                {/* Created at */}
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: "#6b7280",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {formatDate(job.created_at)}
+                </div>
+
+                {/* Arrow */}
+                <div
+                  style={{
+                    color: "#d1d5db",
+                    fontSize: 18,
+                    textAlign: "right",
+                  }}
+                >
+                  ›
+                </div>
+              </Link>
+            );
+          })}
         </div>
       )}
     </main>
-  );
-}
-
-// ─── JobCard ─────────────────────────────────────────────────────────────────
-
-function JobCard({
-  job,
-  contentInfo,
-}: {
-  job: RepurposeJob;
-  contentInfo?: { title: string; platform: string };
-}) {
-  const badge = STATUS_BADGE[job.status] ?? STATUS_BADGE.pending;
-  const derivatives = (job.derivatives ?? []) as Derivative[];
-  const approvedCount = derivatives.filter((d) => d.status === "approved").length;
-  const isReviewable = job.status === "review";
-
-  return (
-    <Link
-      href={isReviewable ? `/repurpose/review?job_id=${job.id}` : "#"}
-      style={{
-        display: "block",
-        border: "1px solid #e5e7eb",
-        borderRadius: 10,
-        padding: "16px 20px",
-        background: "#fff",
-        textDecoration: "none",
-        color: "inherit",
-        cursor: isReviewable ? "pointer" : "default",
-        transition: "border-color 0.15s, box-shadow 0.15s",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "flex-start",
-          gap: 16,
-        }}
-      >
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontWeight: 600,
-              fontSize: 15,
-              color: "#111827",
-              marginBottom: 4,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {contentInfo?.title ?? "Untitled content"}
-          </div>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              fontSize: 13,
-              color: "#6b7280",
-            }}
-          >
-            <span>{formatDate(job.created_at)}</span>
-            {derivatives.length > 0 && (
-              <span>
-                {derivatives.length} format{derivatives.length !== 1 ? "s" : ""}
-                {approvedCount > 0 && ` · ${approvedCount} approved`}
-              </span>
-            )}
-          </div>
-        </div>
-        <div style={{ flexShrink: 0, display: "flex", alignItems: "center", gap: 8 }}>
-          <span
-            style={{
-              background: badge.bg,
-              color: badge.color,
-              borderRadius: 6,
-              padding: "3px 10px",
-              fontSize: 12,
-              fontWeight: 600,
-            }}
-          >
-            {badge.label}
-          </span>
-          {isReviewable && (
-            <span style={{ color: "#d1d5db", fontSize: 18 }}>›</span>
-          )}
-        </div>
-      </div>
-    </Link>
   );
 }

--- a/packages/inngest/src/functions/repurpose-transcript-extraction.ts
+++ b/packages/inngest/src/functions/repurpose-transcript-extraction.ts
@@ -84,14 +84,16 @@ function pickCaptionTrackId(
  * Triggered by: repurpose/job.created
  *
  * Steps:
- *  1. load-job           – Load the repurpose job, source content_item, and
- *                          connected_platform credentials.
- *  2. fetch-yt-captions  – (YouTube only) Download caption track via the
- *                          YouTube Data API captions.list + captions.download.
- *  3. whisper-fallback   – If captions are unavailable, fetch the audio from
- *                          media_urls[0] and transcribe via OpenAI Whisper.
- *  4. store-transcript   – Persist the transcript (or empty string) to
- *                          repurpose_jobs.source_transcript.
+ *  1. load-job             – Load the repurpose job, source content_item, and
+ *                            connected_platform credentials.
+ *  2. (text_import only)   – Short-circuit: use content_items.body directly
+ *                            as the transcript and emit transcript.extracted.
+ *  3. fetch-yt-captions    – (YouTube only) Download caption track via the
+ *                            YouTube Data API captions.list + captions.download.
+ *  4. whisper-fallback     – If captions are unavailable, fetch the audio from
+ *                            media_urls[0] and transcribe via OpenAI Whisper.
+ *  5. store-transcript     – Persist the transcript (or empty string) to
+ *                            repurpose_jobs.source_transcript.
  */
 export const extractRepurposeTranscript = inngest.createFunction(
   {
@@ -121,7 +123,7 @@ export const extractRepurposeTranscript = inngest.createFunction(
 
       const { data: contentItem, error: contentErr } = await supabase
         .from("content_items")
-        .select("id, platform, external_id, media_urls, platform_id")
+        .select("id, platform, content_type, body, external_id, media_urls, platform_id")
         .eq("id", job.source_item_id)
         .single();
 
@@ -151,7 +153,44 @@ export const extractRepurposeTranscript = inngest.createFunction(
       return { contentItem, platformRow };
     });
 
-    // ── Step 2 (YouTube): Try YouTube Data API captions ───────────────────────
+    // ── Step 2 (text_import): Use body directly as the transcript ─────────────
+    // For manually pasted content (newsletters, blog posts, etc.) the body IS
+    // the transcript – no audio extraction needed.
+    if (contentItem.content_type === "text_import") {
+      const textTranscript = (contentItem.body ?? "").trim();
+
+      await step.run("store-transcript", async () => {
+        const supabase = getSupabaseAdmin();
+        const { error } = await supabase
+          .from("repurpose_jobs")
+          .update({ source_transcript: textTranscript })
+          .eq("id", repurpose_job_id);
+
+        if (error) {
+          throw new Error(
+            `[transcript] Failed to store transcript for job ${repurpose_job_id}: ${error.message}`
+          );
+        }
+      });
+
+      await step.sendEvent("emit-transcript-extracted", {
+        name: "repurpose/transcript.extracted",
+        data: {
+          creator_id,
+          repurpose_job_id,
+          transcript_length: textTranscript.length,
+        },
+      });
+
+      return {
+        repurpose_job_id,
+        creator_id,
+        platform: "text_import",
+        transcriptLength: textTranscript.length,
+      };
+    }
+
+    // ── Step 3 (YouTube): Try YouTube Data API captions ───────────────────────
     let transcript: string | null = null;
 
     if (contentItem.platform === "youtube" && contentItem.external_id) {
@@ -229,7 +268,7 @@ export const extractRepurposeTranscript = inngest.createFunction(
       });
     }
 
-    // ── Step 3: Whisper fallback if no captions were obtained ─────────────────
+    // ── Step 4: Whisper fallback if no captions were obtained ─────────────────
     if (!transcript) {
       transcript = await step.run("whisper-fallback", async () => {
         const mediaUrls: string[] = contentItem.media_urls ?? [];
@@ -273,7 +312,7 @@ export const extractRepurposeTranscript = inngest.createFunction(
       });
     }
 
-    // ── Step 4: Persist the transcript ────────────────────────────────────────
+    // ── Step 5: Persist the transcript ────────────────────────────────────────
     await step.run("store-transcript", async () => {
       const supabase = getSupabaseAdmin();
 
@@ -289,7 +328,7 @@ export const extractRepurposeTranscript = inngest.createFunction(
       }
     });
 
-    // ── Step 5: Emit transcript.extracted event for downstream steps ──────────
+    // ── Step 6: Emit transcript.extracted event for downstream steps ──────────
     const transcriptLength = transcript?.length ?? 0;
 
     await step.sendEvent("emit-transcript-extracted", {

--- a/supabase/migrations/20260305000005_add_content_type_to_content_items.sql
+++ b/supabase/migrations/20260305000005_add_content_type_to_content_items.sql
@@ -1,0 +1,20 @@
+-- =============================================================
+-- Meridian – Add content_type to content_items
+-- Migration: 20260305000005_add_content_type_to_content_items.sql
+-- =============================================================
+--
+-- Adds a content_type column to content_items so that manually
+-- pasted text (newsletters, blog posts, etc.) can be tracked
+-- distinctly from platform-synced content.
+--
+-- content_type = 'text_import' → creator pasted text directly;
+--                                 platform is NULL for these rows.
+-- content_type = NULL          → existing platform-synced content
+--                                 (backwards-compatible default).
+
+alter table content_items
+  add column if not exists content_type text;
+
+-- Index to make filtering text_import items fast
+create index if not exists idx_content_items_content_type
+  on content_items (content_type);


### PR DESCRIPTION
## Summary
Adds a new "paste text" workflow to the repurpose feature, allowing creators to directly paste newsletters, blog posts, and other text content for derivative generation without requiring a connected platform source.

## Key Changes

- **New text import page** (`apps/web/app/repurpose/new/page.tsx`): Form-based UI for creators to paste content with title, select target platform, and optionally choose derivative formats
- **New API endpoint** (`apps/web/app/api/repurpose/text-import/route.ts`): Creates a `content_item` with `content_type='text_import'` and immediately triggers a repurpose job
- **Database migration**: Adds `content_type` column to `content_items` table to distinguish text imports from platform-synced content
- **Updated repurpose queue page**: 
  - Converts job list from card layout to table format for better scalability
  - Adds "+ Paste text" CTA button in header
  - Displays derivative formats and approval counts in table
  - Shows content source type (text import vs. platform)
  - Removes separate "Ready for Review" section
- **Updated transcript extraction pipeline**: Detects `content_type='text_import'` and uses the pasted body directly as the transcript, bypassing YouTube caption/Whisper extraction steps

## Implementation Details

- Text imports are stored as `content_items` with `platform=NULL` and `content_type='text_import'`
- The repurpose job creation immediately fires the `repurpose/job.created` event, which the extraction pipeline handles by short-circuiting to the transcript storage step
- Form validation ensures title, body, and target platform are provided before submission
- Derivative formats are optional; if none selected, all formats are generated
- Table layout uses CSS Grid for responsive column sizing and hover states

https://claude.ai/code/session_011Kj6wFaD22TG5Zn2cRGDNv