### PR TITLE
Add publish notifications with in-app bell and email alerts

### DIFF
--- a/apps/web/app/PublishNotificationBell.tsx
+++ b/apps/web/app/PublishNotificationBell.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { createBrowserClient } from "@/lib/supabase/client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface PublishNotification {
+  id: string;
+  type: "published" | "failed_publish";
+  repurpose_job_id: string;
+  format_key: string;
+  platform_label: string;
+  content_title: string | null;
+  external_url: string | null;
+  retry_url: string | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+interface Props {
+  creatorId: string;
+  /** Pre-fetched notifications from the server render (SSR hydration). */
+  initialNotifications: PublishNotification[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function PublishNotificationBell({ creatorId, initialNotifications }: Props) {
+  const [notifications, setNotifications] = useState<PublishNotification[]>(initialNotifications);
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const unreadCount = notifications.filter((n) => !n.read_at).length;
+
+  // ── Supabase Realtime subscription ────────────────────────────────────────
+  useEffect(() => {
+    const supabase = createBrowserClient();
+
+    const channel = supabase
+      .channel(`publish-notifications:${creatorId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "publish_notifications",
+          filter: `creator_id=eq.${creatorId}`,
+        },
+        (payload) => {
+          const newNotif = payload.new as PublishNotification;
+          setNotifications((prev) => [newNotif, ...prev]);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [creatorId]);
+
+  // ── Close dropdown when clicking outside ──────────────────────────────────
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // ── Mark a single notification as read ────────────────────────────────────
+  async function markRead(notifId: string) {
+    const supabase = createBrowserClient();
+    const now = new Date().toISOString();
+
+    await supabase
+      .from("publish_notifications")
+      .update({ read_at: now })
+      .eq("id", notifId);
+
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === notifId ? { ...n, read_at: now } : n))
+    );
+  }
+
+  // ── Mark all as read when dropdown opens ──────────────────────────────────
+  async function handleOpen() {
+    setOpen((v) => !v);
+
+    const unread = notifications.filter((n) => !n.read_at);
+    if (!open && unread.length > 0) {
+      const supabase = createBrowserClient();
+      const now = new Date().toISOString();
+      const ids = unread.map((n) => n.id);
+
+      await supabase
+        .from("publish_notifications")
+        .update({ read_at: now })
+        .in("id", ids);
+
+      setNotifications((prev) =>
+        prev.map((n) => (ids.includes(n.id) ? { ...n, read_at: now } : n))
+      );
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  return (
+    <div ref={dropdownRef} style={{ position: "relative" }}>
+      {/* Bell button */}
+      <button
+        onClick={handleOpen}
+        aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
+        style={{
+          position: "relative",
+          background: "none",
+          border: "1px solid #e2e8f0",
+          borderRadius: 8,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "6px 10px",
+          color: "#374151",
+          fontSize: 18,
+          lineHeight: 1,
+        }}
+      >
+        🔔
+        {unreadCount > 0 && (
+          <span
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              top: -4,
+              right: -4,
+              background: "#dc2626",
+              borderRadius: "50%",
+              color: "#fff",
+              fontSize: 10,
+              fontWeight: 700,
+              minWidth: 16,
+              height: 16,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: "0 3px",
+              lineHeight: 1,
+            }}
+          >
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div
+          role="menu"
+          aria-label="Publish notifications"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 8px)",
+            width: 340,
+            background: "#fff",
+            border: "1px solid #e2e8f0",
+            borderRadius: 10,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.10)",
+            zIndex: 50,
+            overflow: "hidden",
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              padding: "12px 16px",
+              borderBottom: "1px solid #f1f5f9",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <span style={{ fontWeight: 600, fontSize: 14, color: "#0f172a" }}>
+              Publish notifications
+            </span>
+          </div>
+
+          {/* List */}
+          <div style={{ maxHeight: 380, overflowY: "auto" }}>
+            {notifications.length === 0 ? (
+              <div style={{ padding: "24px 16px", textAlign: "center", color: "#94a3b8", fontSize: 14 }}>
+                No notifications yet
+              </div>
+            ) : (
+              notifications.map((n) => (
+                <NotificationRow key={n.id} notification={n} onRead={markRead} />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Notification row ─────────────────────────────────────────────────────────
+
+function NotificationRow({
+  notification: n,
+  onRead,
+}: {
+  notification: PublishNotification;
+  onRead: (id: string) => void;
+}) {
+  const isSuccess = n.type === "published";
+  const accentColor = isSuccess ? "#16a34a" : "#dc2626";
+  const isUnread = !n.read_at;
+
+  const title = n.content_title ?? "Content";
+  const label = isSuccess ? "Published" : "Failed to publish";
+
+  const actionHref = isSuccess ? (n.external_url ?? null) : (n.retry_url ?? null);
+  const actionLabel = isSuccess ? "View post →" : "Retry →";
+
+  return (
+    <div
+      style={{
+        padding: "12px 16px",
+        borderBottom: "1px solid #f8fafc",
+        background: isUnread ? "#fafbff" : "#fff",
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+      }}
+    >
+      {/* Status dot */}
+      <span
+        style={{
+          flexShrink: 0,
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: accentColor,
+          marginTop: 5,
+        }}
+      />
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 6, marginBottom: 2 }}>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: accentColor,
+              textTransform: "uppercase",
+              letterSpacing: "0.5px",
+            }}
+          >
+            {label}
+          </span>
+          <span style={{ fontSize: 11, color: "#94a3b8", marginLeft: "auto", whiteSpace: "nowrap" }}>
+            {timeAgo(n.created_at)}
+          </span>
+        </div>
+
+        <div
+          style={{
+            fontSize: 13,
+            color: "#0f172a",
+            fontWeight: 500,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            marginBottom: 2,
+          }}
+          title={title}
+        >
+          {title}
+        </div>
+
+        <div style={{ fontSize: 12, color: "#64748b", marginBottom: actionHref ? 6 : 0 }}>
+          {n.platform_label}
+        </div>
+
+        {actionHref && (
+          <Link
+            href={actionHref}
+            target={isSuccess ? "_blank" : undefined}
+            rel={isSuccess ? "noopener noreferrer" : undefined}
+            onClick={() => { if (isUnread) onRead(n.id); }}
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: accentColor,
+              textDecoration: "none",
+            }}
+          >
+            {actionLabel}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,6 +5,7 @@ import CreatorDashboard from "./CreatorDashboard";
 import type { DashboardProps } from "./CreatorDashboard";
 import InsightsPanelClient from "./InsightsPanelClient";
 import type { DashboardInsight, InsightEvidenceItem } from "./InsightsPanel";
+import PublishNotificationBell from "./PublishNotificationBell";
 
 /**
  * / — Meridian dashboard home
@@ -26,6 +27,19 @@ export default async function Home() {
   let reauthPlatforms: string[] = [];
   let dashboardContent: DashboardProps["content"] = [];
   let dashboardInsights: DashboardInsight[] = [];
+  let creatorId: string | null = null;
+  let initialNotifications: {
+    id: string;
+    type: "published" | "failed_publish";
+    repurpose_job_id: string;
+    format_key: string;
+    platform_label: string;
+    content_title: string | null;
+    external_url: string | null;
+    retry_url: string | null;
+    read_at: string | null;
+    created_at: string;
+  }[] = [];
 
   if (user) {
     const { data: creator } = await supabase
@@ -35,6 +49,8 @@ export default async function Home() {
       .single();
 
     if (creator) {
+      creatorId = creator.id as string;
+
       // Check for platforms needing re-auth
       const { data: platforms } = await supabase
         .from("connected_platforms")
@@ -43,6 +59,29 @@ export default async function Home() {
         .eq("status", "reauth_required");
 
       reauthPlatforms = (platforms ?? []).map((p) => p.platform as string);
+
+      // Fetch the 20 most recent publish notifications for the bell
+      const { data: notifRows } = await supabase
+        .from("publish_notifications")
+        .select(
+          "id, type, repurpose_job_id, format_key, platform_label, content_title, external_url, retry_url, read_at, created_at"
+        )
+        .eq("creator_id", creator.id)
+        .order("created_at", { ascending: false })
+        .limit(20);
+
+      initialNotifications = (notifRows ?? []).map((n) => ({
+        id: n.id as string,
+        type: n.type as "published" | "failed_publish",
+        repurpose_job_id: n.repurpose_job_id as string,
+        format_key: n.format_key as string,
+        platform_label: n.platform_label as string,
+        content_title: n.content_title as string | null,
+        external_url: n.external_url as string | null,
+        retry_url: n.retry_url as string | null,
+        read_at: n.read_at as string | null,
+        created_at: n.created_at as string,
+      }));
 
       // Fetch content published in the last 364 days (52 weeks for the heatmap;
       // the dashboard's 7d/30d/90d filters narrow it down client-side)
@@ -227,22 +266,30 @@ export default async function Home() {
           <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>
             Dashboard
           </h1>
-          <Link
-            href="/platforms"
-            style={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: "#2563eb",
-              textDecoration: "none",
-              padding: "6px 14px",
-              border: "1px solid #bfdbfe",
-              borderRadius: 6,
-              background: "#eff6ff",
-              whiteSpace: "nowrap",
-            }}
-          >
-            Platform comparison →
-          </Link>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            {creatorId && (
+              <PublishNotificationBell
+                creatorId={creatorId}
+                initialNotifications={initialNotifications}
+              />
+            )}
+            <Link
+              href="/platforms"
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: "#2563eb",
+                textDecoration: "none",
+                padding: "6px 14px",
+                border: "1px solid #bfdbfe",
+                borderRadius: 6,
+                background: "#eff6ff",
+                whiteSpace: "nowrap",
+              }}
+            >
+              Platform comparison →
+            </Link>
+          </div>
         </div>
         <p style={{ color: "#6b7280", margin: 0, fontSize: 15 }}>
           Your content performance at a glance.

--- a/packages/inngest/src/emails/PublishNotificationEmail.tsx
+++ b/packages/inngest/src/emails/PublishNotificationEmail.tsx
@@ -1,0 +1,234 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Preview,
+  Section,
+  Text,
+  Hr,
+} from "@react-email/components";
+import * as React from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PublishNotificationEmailProps {
+  type: "published" | "failed_publish";
+  creatorName: string;
+  platformLabel: string;   // e.g. "Twitter / X Thread"
+  contentTitle: string;    // source content title
+  /** For 'published': link to the live post. */
+  externalUrl?: string;
+  /** For 'failed_publish': link back to the review page to retry. */
+  retryUrl?: string;
+  /** Human-readable publish time, e.g. "Mar 5, 2026 at 9:00 AM PST". */
+  publishedAt: string;
+}
+
+// ─── Email component ──────────────────────────────────────────────────────────
+
+export function PublishNotificationEmail({
+  type,
+  creatorName,
+  platformLabel,
+  contentTitle,
+  externalUrl,
+  retryUrl,
+  publishedAt,
+}: PublishNotificationEmailProps) {
+  const isSuccess = type === "published";
+  const firstName = creatorName.split(" ")[0] ?? creatorName;
+
+  const previewText = isSuccess
+    ? `Your ${platformLabel} post published successfully`
+    : `Publishing failed — retry your ${platformLabel} post`;
+
+  const accentColor = isSuccess ? "#16a34a" : "#dc2626";
+  const accentBg = isSuccess ? "#f0fdf4" : "#fef2f2";
+  const statusLabel = isSuccess ? "Published" : "Failed";
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Body style={styles.body}>
+        <Container style={styles.container}>
+          {/* ── Header ──────────────────────────────────────────────── */}
+          <Section style={styles.header}>
+            <Text style={styles.logo}>MERIDIAN</Text>
+            <Heading style={styles.headline}>
+              {isSuccess ? "Your post is live!" : "Publishing failed"}
+            </Heading>
+            <Text style={styles.subheadline}>
+              {isSuccess
+                ? `Hi ${firstName}, your scheduled content went out on time.`
+                : `Hi ${firstName}, we couldn't publish your content after multiple attempts.`}
+            </Text>
+          </Section>
+
+          {/* ── Status card ─────────────────────────────────────────── */}
+          <Section style={{ ...styles.statusCard, backgroundColor: accentBg, borderLeftColor: accentColor }}>
+            <Text style={{ ...styles.statusBadge, color: accentColor }}>
+              {statusLabel}
+            </Text>
+            <Text style={styles.platformLabel}>{platformLabel}</Text>
+            <Text style={styles.contentTitle}>{contentTitle}</Text>
+            <Text style={styles.publishedAt}>{publishedAt}</Text>
+          </Section>
+
+          {/* ── CTA ─────────────────────────────────────────────────── */}
+          {isSuccess && externalUrl && (
+            <Section style={styles.ctaSection}>
+              <Button href={externalUrl} style={{ ...styles.button, backgroundColor: accentColor }}>
+                View live post →
+              </Button>
+            </Section>
+          )}
+
+          {!isSuccess && retryUrl && (
+            <>
+              <Section style={styles.failureBody}>
+                <Text style={styles.failureText}>
+                  This can happen when a platform token has expired or the
+                  platform API is temporarily unavailable. You can edit and
+                  reschedule the post from the review page.
+                </Text>
+              </Section>
+              <Section style={styles.ctaSection}>
+                <Button href={retryUrl} style={{ ...styles.button, backgroundColor: accentColor }}>
+                  Retry publishing →
+                </Button>
+              </Section>
+            </>
+          )}
+
+          {/* ── Footer ──────────────────────────────────────────────── */}
+          <Hr style={styles.divider} />
+          <Section style={styles.footer}>
+            <Text style={styles.footerText}>
+              You're receiving this because you scheduled content via Meridian.
+            </Text>
+            <Text style={styles.footerText}>
+              © {new Date().getFullYear()} Meridian. All rights reserved.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = {
+  body: {
+    backgroundColor: "#f8fafc",
+    fontFamily:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif',
+    margin: 0,
+    padding: "32px 0",
+  },
+  container: {
+    backgroundColor: "#ffffff",
+    borderRadius: "8px",
+    margin: "0 auto",
+    maxWidth: "560px",
+    overflow: "hidden" as const,
+  },
+  header: {
+    backgroundColor: "#0f172a",
+    padding: "40px 40px 32px",
+  },
+  logo: {
+    color: "#94a3b8",
+    fontSize: "11px",
+    fontWeight: "700" as const,
+    letterSpacing: "4px",
+    margin: "0 0 20px",
+  },
+  headline: {
+    color: "#ffffff",
+    fontSize: "24px",
+    fontWeight: "700" as const,
+    margin: "0 0 10px",
+  },
+  subheadline: {
+    color: "#94a3b8",
+    fontSize: "15px",
+    lineHeight: "1.6",
+    margin: 0,
+  },
+  statusCard: {
+    borderLeft: "4px solid",
+    borderRadius: "0 6px 6px 0",
+    margin: "28px 32px 0",
+    padding: "16px 20px",
+  },
+  statusBadge: {
+    fontSize: "11px",
+    fontWeight: "700" as const,
+    letterSpacing: "1.5px",
+    margin: "0 0 8px",
+    textTransform: "uppercase" as const,
+  },
+  platformLabel: {
+    color: "#64748b",
+    fontSize: "13px",
+    fontWeight: "600" as const,
+    margin: "0 0 4px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.5px",
+  },
+  contentTitle: {
+    color: "#0f172a",
+    fontSize: "16px",
+    fontWeight: "600" as const,
+    lineHeight: "1.4",
+    margin: "0 0 8px",
+  },
+  publishedAt: {
+    color: "#94a3b8",
+    fontSize: "13px",
+    margin: 0,
+  },
+  ctaSection: {
+    padding: "28px 32px 8px",
+  },
+  button: {
+    borderRadius: "6px",
+    color: "#ffffff",
+    display: "inline-block" as const,
+    fontSize: "14px",
+    fontWeight: "600" as const,
+    padding: "12px 24px",
+    textDecoration: "none",
+  },
+  failureBody: {
+    padding: "20px 32px 0",
+  },
+  failureText: {
+    color: "#475569",
+    fontSize: "14px",
+    lineHeight: "1.7",
+    margin: 0,
+  },
+  divider: {
+    borderColor: "#e2e8f0",
+    borderTop: "1px solid #e2e8f0",
+    margin: "32px 0 0",
+  },
+  footer: {
+    padding: "20px 32px 28px",
+  },
+  footerText: {
+    color: "#94a3b8",
+    fontSize: "12px",
+    lineHeight: "1.6",
+    margin: "0 0 4px",
+    textAlign: "center" as const,
+  },
+} as const;
+
+export default PublishNotificationEmail;

--- a/packages/inngest/src/functions/publish-scheduled-derivative.ts
+++ b/packages/inngest/src/functions/publish-scheduled-derivative.ts
@@ -9,6 +9,7 @@
  *  2. load-job             — loads the job, derivative, and platform credentials
  *  3. publish              — calls the per-platform API (Twitter, Instagram, etc.)
  *  4. mark-published       — updates derivative status to "published" + stores external_id
+ *  5. notify-published     — inserts a publish_notifications row (Realtime) + sends email
  *
  * On repeated failure (after Inngest retries are exhausted), the derivative is
  * marked "failed_publish" and an alert event is sent to notify the creator.
@@ -16,9 +17,23 @@
  * Retry policy: 4 attempts with Inngest's default exponential back-off.
  */
 
+import { render } from "@react-email/components";
+import { Resend } from "resend";
+import * as React from "react";
 import { inngest } from "../client";
 import { getSupabaseAdmin } from "../lib/supabaseAdmin";
 import { publishDerivative, type PlatformRow } from "../lib/platform-publishers";
+import { PublishNotificationEmail } from "../emails/PublishNotificationEmail";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const FORMAT_LABELS: Record<string, string> = {
+  twitter_thread: "Twitter / X Thread",
+  linkedin_post: "LinkedIn Post",
+  instagram_caption: "Instagram Caption",
+  newsletter_blurb: "Newsletter Blurb",
+  tiktok_script: "TikTok Script",
+};
 
 // ─── Derivative shape stored in repurpose_jobs.derivatives ───────────────────
 
@@ -47,6 +62,19 @@ const FORMAT_TO_PLATFORM_DB: Record<string, string> = {
   newsletter_blurb: "other", // Beehiiv is stored as 'other'
   tiktok_script: "tiktok",
 };
+
+// ─── Helper: format a Date as a readable publish timestamp ───────────────────
+
+function fmtPublishedAt(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
 
 // ─── Inngest function ─────────────────────────────────────────────────────────
 
@@ -168,17 +196,17 @@ export const publishScheduledDerivative = inngest.createFunction(
     });
 
     // ── Step 4: mark derivative as published ──────────────────────────────
-    await step.run("mark-published", async () => {
+    const markResult = await step.run("mark-published", async () => {
       const supabase = getSupabaseAdmin();
       const now = new Date().toISOString();
 
       const { data: job } = await supabase
         .from("repurpose_jobs")
-        .select("derivatives, scheduled_derivative_ids")
+        .select("derivatives, scheduled_derivative_ids, source_item_id")
         .eq("id", repurpose_job_id)
         .single();
 
-      if (!job) return;
+      if (!job) return { now, contentTitle: null as string | null };
 
       const derivatives = (job.derivatives ?? []) as Derivative[];
       const updatedDerivatives = derivatives.map((d) => {
@@ -203,6 +231,74 @@ export const publishScheduledDerivative = inngest.createFunction(
           scheduled_derivative_ids: scheduledIds,
         })
         .eq("id", repurpose_job_id);
+
+      // Fetch the source content title for the notification
+      let contentTitle: string | null = null;
+      if (job.source_item_id) {
+        const { data: contentItem } = await supabase
+          .from("content_items")
+          .select("title")
+          .eq("id", job.source_item_id as string)
+          .single();
+        contentTitle = (contentItem?.title as string) ?? null;
+      }
+
+      return { now, contentTitle };
+    });
+
+    // ── Step 5: send in-app + email notification ───────────────────────────
+    await step.run("notify-published", async () => {
+      const supabase = getSupabaseAdmin();
+      const platformLabel = FORMAT_LABELS[format_key] ?? format_key;
+      const contentTitle = markResult.contentTitle ?? "your content";
+
+      // Fetch creator profile for the email
+      const { data: creator } = await supabase
+        .from("creators")
+        .select("email, display_name")
+        .eq("id", creator_id)
+        .single();
+
+      if (!creator) return;
+
+      // Insert in-app notification (Realtime will push to connected clients)
+      await supabase.from("publish_notifications").insert({
+        creator_id,
+        type: "published",
+        repurpose_job_id,
+        format_key,
+        platform_label: platformLabel,
+        content_title: contentTitle,
+        external_url: publishResult.url ?? null,
+      });
+
+      // Send transactional email via Resend
+      const resend = new Resend(process.env.RESEND_API_KEY!);
+
+      const html = await render(
+        React.createElement(PublishNotificationEmail, {
+          type: "published",
+          creatorName: creator.display_name as string,
+          platformLabel,
+          contentTitle,
+          externalUrl: publishResult.url ?? undefined,
+          publishedAt: fmtPublishedAt(markResult.now),
+        })
+      );
+
+      const { error } = await resend.emails.send({
+        from: "Meridian <notifications@meridian.app>",
+        to: creator.email as string,
+        subject: `Your ${platformLabel} post is live`,
+        html,
+      });
+
+      if (error) {
+        // Log but don't throw — the post is already published; email is best-effort
+        console.error(
+          `[notify-published] Resend failed for creator ${creator_id}: ${JSON.stringify(error)}`
+        );
+      }
     });
 
     return {
@@ -220,7 +316,8 @@ export const publishScheduledDerivative = inngest.createFunction(
 
 /**
  * Marks the derivative as "failed_publish" when all Inngest retries are exhausted.
- * Fires a creator alert so they can take action.
+ * Inserts a publish_notifications row (Realtime) and sends a failure email with
+ * a retry link so the creator can reschedule from the review page.
  *
  * This is registered as a separate Inngest function using onFailure.
  */
@@ -247,17 +344,22 @@ export const handlePublishFailure = inngest.createFunction(
     const { creator_id, repurpose_job_id, format_key } =
       originalEvent.data;
 
-    await step.run("mark-failed", async () => {
+    const failureMessage =
+      (event.data.error as { message?: string } | undefined)?.message ??
+      "Publishing failed after multiple retries.";
+
+    // ── Step: mark derivative as failed + load context for notifications ──
+    const failedContext = await step.run("mark-failed", async () => {
       const supabase = getSupabaseAdmin();
       const now = new Date().toISOString();
 
       const { data: job } = await supabase
         .from("repurpose_jobs")
-        .select("derivatives, scheduled_derivative_ids")
+        .select("derivatives, scheduled_derivative_ids, source_item_id")
         .eq("id", repurpose_job_id)
         .single();
 
-      if (!job) return;
+      if (!job) return { contentTitle: null as string | null, now };
 
       const derivatives = (job.derivatives ?? []) as Derivative[];
       const updatedDerivatives = derivatives.map((d) => {
@@ -265,9 +367,7 @@ export const handlePublishFailure = inngest.createFunction(
         return {
           ...d,
           status: "failed_publish",
-          publish_error:
-            (event.data.error as { message?: string } | undefined)?.message ??
-            "Publishing failed after multiple retries.",
+          publish_error: failureMessage,
           updated_at: now,
         };
       });
@@ -283,11 +383,28 @@ export const handlePublishFailure = inngest.createFunction(
           scheduled_derivative_ids: scheduledIds,
         })
         .eq("id", repurpose_job_id);
+
+      // Fetch source content title
+      let contentTitle: string | null = null;
+      if (job.source_item_id) {
+        const { data: contentItem } = await supabase
+          .from("content_items")
+          .select("title")
+          .eq("id", job.source_item_id as string)
+          .single();
+        contentTitle = (contentItem?.title as string) ?? null;
+      }
+
+      return { contentTitle, now };
     });
 
-    // Fetch creator email for alert notification
+    // ── Step: send in-app notification + failure email ─────────────────────
     await step.run("alert-creator", async () => {
       const supabase = getSupabaseAdmin();
+      const platformLabel = FORMAT_LABELS[format_key] ?? format_key;
+      const contentTitle = failedContext.contentTitle ?? "your content";
+      const retryUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/repurpose/review?job_id=${repurpose_job_id}`;
+
       const { data: creator } = await supabase
         .from("creators")
         .select("email, display_name")
@@ -296,14 +413,43 @@ export const handlePublishFailure = inngest.createFunction(
 
       if (!creator) return;
 
-      // Log the failure — in production this would trigger a Resend email
-      // similar to the weekly digest pattern. The creator email/Resend
-      // integration follows the same pattern as WeeklyDigestEmail.
-      console.error(
-        `[publish-failure] Creator ${creator.display_name} (${creator.email}) ` +
-          `failed to publish ${format_key} for job ${repurpose_job_id}. ` +
-          `Error: ${(event.data.error as { message?: string } | undefined)?.message}`
+      // Insert in-app notification with retry link
+      await supabase.from("publish_notifications").insert({
+        creator_id,
+        type: "failed_publish",
+        repurpose_job_id,
+        format_key,
+        platform_label: platformLabel,
+        content_title: contentTitle,
+        retry_url: retryUrl,
+      });
+
+      // Send failure email via Resend
+      const resend = new Resend(process.env.RESEND_API_KEY!);
+
+      const html = await render(
+        React.createElement(PublishNotificationEmail, {
+          type: "failed_publish",
+          creatorName: creator.display_name as string,
+          platformLabel,
+          contentTitle,
+          retryUrl,
+          publishedAt: fmtPublishedAt(failedContext.now),
+        })
       );
+
+      const { error } = await resend.emails.send({
+        from: "Meridian <notifications@meridian.app>",
+        to: creator.email as string,
+        subject: `Action required: ${platformLabel} publishing failed`,
+        html,
+      });
+
+      if (error) {
+        console.error(
+          `[alert-creator] Resend failed for creator ${creator_id}: ${JSON.stringify(error)}`
+        );
+      }
     });
 
     return {

--- a/supabase/migrations/20260305000007_add_publish_notifications.sql
+++ b/supabase/migrations/20260305000007_add_publish_notifications.sql
@@ -1,0 +1,90 @@
+-- =============================================================
+-- Meridian – Add publish_notifications table
+-- Migration: 20260305000007_add_publish_notifications.sql
+--
+-- Stores in-app notifications for derivative publish success/failure.
+-- Supabase Realtime is enabled on this table so the browser client
+-- receives push updates without polling.
+--
+-- Changes:
+--   1. Create publish_notifications table
+--   2. Enable RLS with owner-only policies
+--   3. Add table to the Supabase Realtime publication
+-- =============================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Create table
+-- ---------------------------------------------------------------------------
+create table if not exists publish_notifications (
+  id                uuid primary key default gen_random_uuid(),
+  creator_id        uuid not null references creators (id) on delete cascade,
+
+  -- 'published' or 'failed_publish'
+  type              text not null check (type in ('published', 'failed_publish')),
+
+  repurpose_job_id  uuid not null,
+  format_key        text not null,
+
+  -- Human-readable labels stored at write time so reads are cheap
+  platform_label    text not null,  -- e.g. "Twitter / X Thread"
+  content_title     text,           -- source content title for context
+
+  -- For 'published': direct link to the live post
+  external_url      text,
+
+  -- For 'failed_publish': link back to the review page so the creator can retry
+  retry_url         text,
+
+  -- NULL until the creator opens/dismisses the notification
+  read_at           timestamptz,
+
+  created_at        timestamptz not null default now()
+);
+
+comment on table publish_notifications is
+  'In-app notifications fired when a scheduled derivative publishes or fails. '
+  'Realtime is enabled so the browser receives push updates immediately.';
+
+comment on column publish_notifications.retry_url is
+  'URL to the derivative review page; only populated for failed_publish notifications.';
+
+-- Index for fast per-creator unread queries (the common case)
+create index if not exists idx_publish_notifications_creator_unread
+  on publish_notifications (creator_id, created_at desc)
+  where read_at is null;
+
+-- ---------------------------------------------------------------------------
+-- 2. Row-Level Security
+-- ---------------------------------------------------------------------------
+alter table publish_notifications enable row level security;
+
+-- Creators can only see their own notifications
+create policy "publish_notifications: owner select"
+  on publish_notifications for select
+  using (
+    creator_id in (
+      select id from creators where auth_user_id = auth.uid()
+    )
+  );
+
+-- The service-role key (used by Inngest) bypasses RLS for inserts.
+-- The authenticated client can mark its own notifications as read.
+create policy "publish_notifications: owner update"
+  on publish_notifications for update
+  using (
+    creator_id in (
+      select id from creators where auth_user_id = auth.uid()
+    )
+  )
+  with check (
+    creator_id in (
+      select id from creators where auth_user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. Enable Realtime
+--    Adds the table to the default supabase_realtime publication so that
+--    clients can subscribe to INSERT/UPDATE changes via Supabase channels.
+-- ---------------------------------------------------------------------------
+alter publication supabase_realtime add table publish_notifications;


### PR DESCRIPTION
## Summary
Adds a comprehensive notification system for derivative publishing events. Creators now receive real-time in-app notifications via a bell icon on the dashboard, plus transactional emails when content publishes successfully or fails. The system uses Supabase Realtime for instant push updates and includes retry functionality for failed publishes.

## Key Changes

- **New `publish_notifications` table** (`20260305000007_add_publish_notifications.sql`)
  - Stores publish success/failure events with creator ownership
  - Includes RLS policies for secure per-creator access
  - Enabled for Supabase Realtime so browser clients receive instant push updates
  - Tracks read status and includes links to live posts or retry pages

- **PublishNotificationBell component** (`apps/web/app/PublishNotificationBell.tsx`)
  - Client-side React component with bell icon showing unread count badge
  - Dropdown menu displaying recent notifications (up to 20)
  - Realtime subscription to `publish_notifications` table for instant updates
  - Auto-marks notifications as read when dropdown opens
  - Responsive styling with success (green) and failure (red) status indicators
  - Links to external posts or retry pages with `timeAgo()` formatting

- **PublishNotificationEmail component** (`packages/inngest/src/emails/PublishNotificationEmail.tsx`)
  - React Email template for transactional emails
  - Separate layouts for success ("Your post is live!") and failure ("Publishing failed") scenarios
  - Includes platform label, content title, and formatted publish timestamp
  - CTA buttons link to live posts or retry review page
  - Failure emails include explanation and reschedule guidance

- **Updated publish workflow** (`packages/inngest/src/functions/publish-scheduled-derivative.ts`)
  - Added `notify-published` step after successful publish to insert in-app notification and send email
  - Enhanced `handlePublishFailure` with `alert-creator` step for failure notifications
  - Fetches source content title from `content_items` for notification context
  - Uses `FORMAT_LABELS` mapping to display human-readable platform names
  - Includes `fmtPublishedAt()` helper for readable timestamp formatting
  - Retry URL points to `/repurpose/review?job_id=...` for easy rescheduling

- **Dashboard integration** (`apps/web/app/page.tsx`)
  - Fetches 20 most recent notifications during SSR for hydration
  - Renders `PublishNotificationBell` in dashboard header next to platform comparison link
  - Passes `creatorId` and `initialNotifications` to enable Realtime subscription

## Implementation Details

- Notifications are inserted by Inngest (service-role) after publish success/failure, bypassing RLS
- Authenticated clients can only read/update their own notifications via RLS policies
- Email sending via Resend is best-effort; failures are logged but don't block the publish workflow
- Unread count badge shows "9+" for 10+ unread notifications
- Dropdown auto-closes when clicking outside; notifications auto-mark as read on open
- Platform labels are stored at write time for cheap reads and consistent display

https://claude.ai/code/session_01EBgKfZV62ipNcYEDTWUEyy