### PR TITLE
Add usage summary card to billing page

### DIFF
--- a/apps/web/app/settings/billing/BillingClient.tsx
+++ b/apps/web/app/settings/billing/BillingClient.tsx
@@ -41,7 +41,147 @@ const PLANS: Record<Plan, PlanConfig> = {
   },
 };
 
-// ─── Sub-components ───────────────────────────────────────────────────────────
+const TIER_COLORS: Record<"free" | "creator" | "pro", string> = {
+  free: "#6b7280",
+  creator: "#2563eb",
+  pro: "#7c3aed",
+};
+
+// ─── Usage summary card ───────────────────────────────────────────────────────
+
+function UsageSummaryCard({
+  currentTier,
+  repurposeJobsUsed,
+  repurposeJobsLimit,
+  nextBillingDate,
+}: {
+  currentTier: "free" | "creator" | "pro";
+  repurposeJobsUsed: number;
+  repurposeJobsLimit: number | null;
+  nextBillingDate: string | null;
+}) {
+  const tierColor = TIER_COLORS[currentTier];
+  const tierLabel =
+    currentTier === "free"
+      ? "Free"
+      : currentTier === "creator"
+      ? "Creator"
+      : "Pro";
+
+  const usageLabel =
+    repurposeJobsLimit === null
+      ? `${repurposeJobsUsed} / ∞`
+      : `${repurposeJobsUsed} / ${repurposeJobsLimit}`;
+
+  const usagePct =
+    repurposeJobsLimit === null
+      ? 0
+      : Math.min((repurposeJobsUsed / repurposeJobsLimit) * 100, 100);
+
+  return (
+    <div
+      style={{
+        border: "1px solid #e5e7eb",
+        borderRadius: 12,
+        padding: 24,
+        marginBottom: 28,
+        background: "#f9fafb",
+      }}
+    >
+      <h2 style={{ fontSize: 15, fontWeight: 700, margin: "0 0 16px", color: "#111827" }}>
+        Current usage
+      </h2>
+
+      <div style={{ display: "flex", gap: 0, flexWrap: "wrap" }}>
+        {/* Plan */}
+        <div
+          style={{
+            flex: "1 1 140px",
+            paddingRight: 24,
+            borderRight: "1px solid #e5e7eb",
+            marginRight: 24,
+            marginBottom: 8,
+          }}
+        >
+          <div style={{ fontSize: 12, color: "#6b7280", fontWeight: 600, letterSpacing: "0.05em", textTransform: "uppercase", marginBottom: 6 }}>
+            Plan
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span
+              style={{
+                display: "inline-block",
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                background: tierColor,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: 18, fontWeight: 700, color: tierColor }}>
+              {tierLabel}
+            </span>
+          </div>
+        </div>
+
+        {/* Repurpose jobs */}
+        <div
+          style={{
+            flex: "1 1 160px",
+            paddingRight: 24,
+            borderRight: nextBillingDate ? "1px solid #e5e7eb" : undefined,
+            marginRight: nextBillingDate ? 24 : 0,
+            marginBottom: 8,
+          }}
+        >
+          <div style={{ fontSize: 12, color: "#6b7280", fontWeight: 600, letterSpacing: "0.05em", textTransform: "uppercase", marginBottom: 6 }}>
+            Repurpose jobs
+          </div>
+          <div style={{ fontSize: 18, fontWeight: 700, color: "#111827", marginBottom: 8 }}>
+            {usageLabel}
+            <span style={{ fontSize: 13, fontWeight: 400, color: "#6b7280", marginLeft: 4 }}>
+              this month
+            </span>
+          </div>
+          {repurposeJobsLimit !== null && (
+            <div
+              style={{
+                height: 4,
+                background: "#e5e7eb",
+                borderRadius: 99,
+                overflow: "hidden",
+                maxWidth: 140,
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${usagePct}%`,
+                  background: usagePct >= 90 ? "#ef4444" : usagePct >= 70 ? "#f59e0b" : "#2563eb",
+                  borderRadius: 99,
+                  transition: "width 0.3s",
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Next billing date */}
+        {nextBillingDate && (
+          <div style={{ flex: "1 1 120px", marginBottom: 8 }}>
+            <div style={{ fontSize: 12, color: "#6b7280", fontWeight: 600, letterSpacing: "0.05em", textTransform: "uppercase", marginBottom: 6 }}>
+              Next billing
+            </div>
+            <div style={{ fontSize: 18, fontWeight: 700, color: "#111827" }}>
+              {nextBillingDate}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Plan card ────────────────────────────────────────────────────────────────
 
 function PlanCard({
   plan,
@@ -124,11 +264,17 @@ function PlanCard({
 interface BillingClientProps {
   currentTier: "free" | "creator" | "pro";
   hasStripeCustomer: boolean;
+  repurposeJobsUsed: number;
+  repurposeJobsLimit: number | null;
+  nextBillingDate: string | null;
 }
 
 export default function BillingClient({
   currentTier,
   hasStripeCustomer,
+  repurposeJobsUsed,
+  repurposeJobsLimit,
+  nextBillingDate,
 }: BillingClientProps) {
   const [checkoutLoading, setCheckoutLoading] = useState<Plan | null>(null);
   const [portalLoading, setPortalLoading] = useState(false);
@@ -178,6 +324,14 @@ export default function BillingClient({
 
   return (
     <div>
+      {/* Usage summary */}
+      <UsageSummaryCard
+        currentTier={currentTier}
+        repurposeJobsUsed={repurposeJobsUsed}
+        repurposeJobsLimit={repurposeJobsLimit}
+        nextBillingDate={nextBillingDate}
+      />
+
       {/* Current tier banner for free users */}
       {currentTier === "free" && (
         <div

--- a/apps/web/app/settings/billing/page.tsx
+++ b/apps/web/app/settings/billing/page.tsx
@@ -1,14 +1,17 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createServerClient } from "@/lib/supabase/server";
+import { stripe } from "@/lib/stripe";
+import { TIER_LIMITS } from "@/lib/subscription";
 import BillingClient from "./BillingClient";
 
 /**
  * /settings/billing – Subscription & billing management
  *
- * Server component. Fetches the creator's current subscription tier and
- * Stripe customer status, then hands the data to the client component for
- * interactive upgrade/portal actions.
+ * Server component. Fetches:
+ *  - Creator's current subscription tier & Stripe IDs
+ *  - Next billing date from Stripe (paid plans only)
+ *  - Repurpose job usage for the current calendar month
  */
 export default async function BillingPage() {
   const supabase = await createServerClient();
@@ -23,13 +26,65 @@ export default async function BillingPage() {
 
   const { data: creator } = await supabase
     .from("creators")
-    .select("subscription_tier, stripe_customer_id")
+    .select("id, subscription_tier, stripe_customer_id, stripe_subscription_id")
     .eq("auth_user_id", user.id)
     .single();
 
   const currentTier =
     (creator?.subscription_tier as "free" | "creator" | "pro" | null) ?? "free";
   const hasStripeCustomer = Boolean(creator?.stripe_customer_id);
+
+  // ── Next billing date from Stripe ──────────────────────────────────────────
+  let nextBillingDate: string | null = null;
+
+  if (creator?.stripe_subscription_id) {
+    try {
+      const subscription = await stripe.subscriptions.retrieve(
+        creator.stripe_subscription_id
+      );
+      if (
+        subscription.status === "active" ||
+        subscription.status === "trialing"
+      ) {
+        nextBillingDate = new Date(
+          subscription.current_period_end * 1000
+        ).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        });
+      }
+    } catch {
+      // Non-fatal: leave nextBillingDate as null
+    }
+  }
+
+  // ── Repurpose job usage this month ─────────────────────────────────────────
+  let repurposeJobsUsed = 0;
+
+  if (creator?.id) {
+    const monthStart = new Date(
+      Date.UTC(
+        new Date().getUTCFullYear(),
+        new Date().getUTCMonth(),
+        1
+      )
+    ).toISOString();
+
+    const { count } = await supabase
+      .from("repurpose_jobs")
+      .select("id", { count: "exact", head: true })
+      .eq("creator_id", creator.id)
+      .gte("created_at", monthStart);
+
+    repurposeJobsUsed = count ?? 0;
+  }
+
+  const tierLimits = TIER_LIMITS[currentTier];
+  const repurposeJobsLimit =
+    tierLimits.repurposeJobsPerMonth === Infinity
+      ? null
+      : tierLimits.repurposeJobsPerMonth;
 
   return (
     <main
@@ -65,6 +120,9 @@ export default async function BillingPage() {
       <BillingClient
         currentTier={currentTier}
         hasStripeCustomer={hasStripeCustomer}
+        repurposeJobsUsed={repurposeJobsUsed}
+        repurposeJobsLimit={repurposeJobsLimit}
+        nextBillingDate={nextBillingDate}
       />
     </main>
   );


### PR DESCRIPTION
## Summary
Added a new usage summary card to the billing page that displays the user's current subscription tier, repurpose job usage for the month, and next billing date.

## Key Changes
- **New `UsageSummaryCard` component** in `BillingClient.tsx`:
  - Displays current subscription tier with color-coded indicator
  - Shows repurpose jobs usage with progress bar (color changes based on usage: blue <70%, amber 70-89%, red ≥90%)
  - Shows next billing date for active/trialing subscriptions
  - Responsive flex layout that adapts to different screen sizes

- **Enhanced `BillingPage` server component** in `page.tsx`:
  - Fetches next billing date from Stripe for paid subscriptions
  - Calculates repurpose job usage for the current calendar month from the database
  - Retrieves tier limits from `TIER_LIMITS` configuration
  - Passes usage data to `BillingClient` component

- **Updated `BillingClient` interface**:
  - Added props: `repurposeJobsUsed`, `repurposeJobsLimit`, `nextBillingDate`
  - Renders `UsageSummaryCard` at the top of the billing page

## Implementation Details
- Usage calculation queries `repurpose_jobs` table filtered by creator ID and current month
- Next billing date is formatted as "Mon DD, YYYY" (e.g., "Jan 15, 2024")
- Unlimited plans show "∞" symbol instead of a numeric limit
- Progress bar only displays for plans with usage limits (not for unlimited plans)
- Graceful error handling for Stripe API calls (non-fatal if retrieval fails)

https://claude.ai/code/session_01WPAqH1SyhCBZjbc2SuCXus