### PR TITLE
Re-enable automatic EAS builds on push and pull requests

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,13 +1,12 @@
 name: EAS Build
 
-on: {}
-  # Temporarily disabled automatic EAS builds
-  # push:
-  #   branches:
-  #     - main
-  # pull_request:
-  #   branches:
-  #     - main
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Re-enables the EAS Build workflow that was previously disabled, allowing automatic builds to run on push and pull request events to the main branch.

## Changes
- Uncommented the `on` trigger configuration to restore automatic workflow execution
- Restored push trigger for the main branch
- Restored pull_request trigger for the main branch
- Removed the empty `on: {}` configuration that was disabling the workflow

## Details
The EAS Build workflow will now automatically execute when:
- Code is pushed to the main branch
- A pull request is opened or updated against the main branch

This restores the CI/CD pipeline for building and validating changes before they are merged.

https://claude.ai/code/session_01PtRdZNACPXXAFZYT3qeJ6p