### PR TITLE
Configure production site URL and tighten OAuth security settings

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,7 +3,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 
 # Public base URL (no trailing slash) – used as the OAuth redirect_uri origin
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+# Production: https://app.meridian.so  |  Local dev: http://localhost:3000
+NEXT_PUBLIC_SITE_URL=https://app.meridian.so
+
+# Supabase Auth site_url (must match NEXT_PUBLIC_SITE_URL; used in supabase/config.toml via env(SITE_URL))
+# Production: https://app.meridian.so  |  Local dev: http://127.0.0.1:3000
+SITE_URL=https://app.meridian.so
 
 # YouTube / Google OAuth credentials
 # Create an OAuth 2.0 Client ID at https://console.cloud.google.com/apis/credentials

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -147,10 +147,11 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "env(SITE_URL)"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 # Supports wildcards: ** matches any sequence. Expo Go uses 127.0.0.1 for emulator, LAN IPs for devices.
 additional_redirect_urls = [
+  "http://127.0.0.1:3000",
   "https://127.0.0.1:3000",
   "meridian://auth/callback",
   "exp://127.0.0.1:**",
@@ -327,7 +328,7 @@ client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 # DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 # If enabled, the nonce check will be skipped. Only use for strictly-local development; otherwise weakens OIDC verification.
-skip_nonce_check = true
+skip_nonce_check = false
 
 # Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
 # You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.


### PR DESCRIPTION
## Summary
Updated environment configuration and Supabase auth settings to support production deployment while maintaining security best practices for local development.

## Key Changes
- **Environment Configuration**: Updated `.env.example` to use production URL (`https://app.meridian.so`) as the default `NEXT_PUBLIC_SITE_URL` with clear comments distinguishing production vs. local dev values
- **Supabase Site URL**: Added new `SITE_URL` environment variable to `.env.example` for use in `supabase/config.toml`, allowing environment-based configuration instead of hardcoded values
- **Dynamic Config**: Changed `supabase/config.toml` to use `env(SITE_URL)` instead of hardcoded localhost URL, enabling environment-specific configuration
- **Redirect URLs**: Added `http://127.0.0.1:3000` to `additional_redirect_urls` to support local development alongside HTTPS variant
- **Security Hardening**: Disabled `skip_nonce_check` in Google OAuth configuration (changed from `true` to `false`) to enforce proper OIDC nonce verification in production

## Implementation Details
The changes enable a single codebase to work across environments by:
1. Using environment variables for site URLs instead of hardcoded values
2. Maintaining backward compatibility with local development (127.0.0.1:3000)
3. Strengthening OAuth security by re-enabling nonce verification, which should only be skipped for strictly local development

https://claude.ai/code/session_01DyibHddi6LeG1WCg9eoCzb