### PR TITLE
Remove Facebook platform support from repurpose feature

### DIFF
--- a/apps/web/app/RepurposeModal.tsx
+++ b/apps/web/app/RepurposeModal.tsx
@@ -21,7 +21,6 @@ const ALL_PLATFORMS: { value: string; label: string }[] = [
   { value: "tiktok", label: "TikTok" },
   { value: "twitter", label: "Twitter / X" },
   { value: "linkedin", label: "LinkedIn" },
-  { value: "facebook", label: "Facebook" },
   { value: "podcast", label: "Podcast" },
   { value: "other", label: "Other" },
 ];

--- a/apps/web/app/api/repurpose/route.ts
+++ b/apps/web/app/api/repurpose/route.ts
@@ -10,7 +10,6 @@ const VALID_PLATFORMS = new Set([
   "tiktok",
   "twitter",
   "linkedin",
-  "facebook",
   "podcast",
   "other",
 ]);

--- a/apps/web/app/api/repurpose/text-import/route.ts
+++ b/apps/web/app/api/repurpose/text-import/route.ts
@@ -8,7 +8,6 @@ const VALID_PLATFORMS = new Set([
   "tiktok",
   "twitter",
   "linkedin",
-  "facebook",
   "podcast",
   "other",
 ]);

--- a/apps/web/app/repurpose/new/page.tsx
+++ b/apps/web/app/repurpose/new/page.tsx
@@ -12,7 +12,6 @@ const ALL_PLATFORMS: { value: string; label: string }[] = [
   { value: "instagram", label: "Instagram" },
   { value: "tiktok", label: "TikTok" },
   { value: "youtube", label: "YouTube" },
-  { value: "facebook", label: "Facebook" },
   { value: "podcast", label: "Podcast" },
   { value: "other", label: "Other" },
 ];

--- a/supabase/migrations/20260222000000_initial_schema.sql
+++ b/supabase/migrations/20260222000000_initial_schema.sql
@@ -12,7 +12,6 @@ create type platform_name as enum (
   'tiktok',
   'twitter',
   'linkedin',
-  'facebook',
   'podcast',
   'other'
 );


### PR DESCRIPTION
## Summary
This PR removes Facebook as a supported platform option from the repurpose feature across the application.

## Key Changes
- Removed Facebook from the platform selection dropdown in `RepurposeModal.tsx`
- Removed Facebook from the platform selection dropdown in `repurpose/new/page.tsx`
- Removed "facebook" from the `VALID_PLATFORMS` set in the repurpose API route handler
- Removed "facebook" from the `VALID_PLATFORMS` set in the text import API route handler
- Removed 'facebook' from the `platform_name` enum type definition in the database schema migration

## Implementation Details
The changes are consistent across all layers of the application:
- **UI Layer**: Removed from both modal and page platform selection components
- **API Layer**: Removed from validation sets in both repurpose and text-import endpoints
- **Database Layer**: Removed from the PostgreSQL enum type that defines valid platform values

This ensures that Facebook cannot be selected as a target platform through any user interface or API endpoint, and the database schema reflects this constraint.

https://claude.ai/code/session_01GQNCxHFVxDmcGkAb3YQyZ1