### PR TITLE
Add environment variable documentation for third-party services

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,2 +1,6 @@
 EXPO_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+
+# Base URL of the Meridian web API (no trailing slash)
+# Production: https://app.meridian.so  |  Local dev: http://localhost:3000
+EXPO_PUBLIC_API_URL=https://app.meridian.so

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -57,3 +57,28 @@ STRIPE_V2_WEBHOOK_SECRET=whsec_<your-v2-stripe-webhook-signing-secret>
 
 STRIPE_CREATOR_PRICE_ID=price_<creator-plan-price-id>
 STRIPE_PRO_PRICE_ID=price_<pro-plan-price-id>
+
+# ─── Inngest ────────────────────────────────────────────────────────────────────
+# Signing key and event key from https://app.inngest.com/env/production/manage/signing-key
+# INNGEST_SIGNING_KEY verifies that webhook requests come from Inngest servers
+# INNGEST_EVENT_KEY is used when sending events from the app to Inngest
+INNGEST_SIGNING_KEY=signkey-prod-<your-inngest-signing-key>
+INNGEST_EVENT_KEY=<your-inngest-event-key>
+
+# ─── AI / LLM ───────────────────────────────────────────────────────────────────
+# Anthropic Claude – used for content derivative generation
+# Get your key at https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-<your-anthropic-api-key>
+
+# OpenAI – used for audio transcription via Whisper
+# Get your key at https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-<your-openai-api-key>
+
+# ─── Email ──────────────────────────────────────────────────────────────────────
+# Resend – used for transactional emails (weekly digest, publish notifications)
+# Get your key at https://resend.com/api-keys
+RESEND_API_KEY=re_<your-resend-api-key>
+
+# Public app URL used in email links (no trailing slash)
+# Production: https://app.meridian.so  |  Local dev: http://localhost:3000
+NEXT_PUBLIC_APP_URL=https://app.meridian.so


### PR DESCRIPTION
## Summary
Updated `.env.example` files across web and mobile apps to document all required third-party service integrations and their configuration.

## Key Changes

**apps/web/.env.example:**
- Added Inngest configuration variables (`INNGEST_SIGNING_KEY`, `INNGEST_EVENT_KEY`) with documentation on their purpose and where to obtain them
- Added AI/LLM service keys:
  - `ANTHROPIC_API_KEY` for Claude-based content derivative generation
  - `OPENAI_API_KEY` for Whisper audio transcription
- Added email service configuration:
  - `RESEND_API_KEY` for transactional emails (weekly digest, publish notifications)
  - `NEXT_PUBLIC_APP_URL` for email link generation with environment-specific examples
- Included helpful comments with links to obtain credentials and usage context

**apps/mobile/.env.example:**
- Added `EXPO_PUBLIC_API_URL` to specify the base URL for the Meridian web API
- Included environment-specific examples (production vs. local development)

## Implementation Details
- All new variables include descriptive comments explaining their purpose
- Documentation includes direct links to credential management pages for each service
- Environment-specific examples provided (production URLs vs. localhost for development)
- Consistent formatting and organization with existing environment variables

https://claude.ai/code/session_011jEUQCSbguqfcW59MvEiHa