### PR TITLE
Improve Stripe webhook error handling for missing price IDs

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -62,7 +62,15 @@ async function handleCheckoutSessionCompleted(
   const subscription = await stripe.subscriptions.retrieve(subscriptionId);
   const tier = tierFromSubscription(subscription);
 
-  if (!tier || !isActiveStatus(subscription.status)) return;
+  if (!isActiveStatus(subscription.status)) return;
+
+  if (!tier) {
+    const priceId = subscription.items.data[0]?.price?.id ?? "(unknown)";
+    throw new Error(
+      `Unrecognized price ID "${priceId}" on new subscription ${subscription.id} — ` +
+        `verify STRIPE_CREATOR_PRICE_ID / STRIPE_PRO_PRICE_ID env vars`
+    );
+  }
 
   const { error } = await getAdminClient()
     .from("creators")
@@ -85,8 +93,23 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
       : subscription.customer.id;
 
   const tier = tierFromSubscription(subscription);
-  const newTier: "free" | "creator" | "pro" =
-    tier && isActiveStatus(subscription.status) ? tier : "free";
+
+  let newTier: "free" | "creator" | "pro";
+  if (!isActiveStatus(subscription.status)) {
+    // Subscription cancelled, past_due, etc. — intentional downgrade to free.
+    newTier = "free";
+  } else if (!tier) {
+    // Subscription is active but the price ID is unrecognised — this is a
+    // configuration error, not a valid "free" state. Throw so the error is
+    // logged and Stripe can see the failure rather than silently downgrading.
+    const priceId = subscription.items.data[0]?.price?.id ?? "(unknown)";
+    throw new Error(
+      `Unrecognized price ID "${priceId}" on active subscription ${subscription.id} — ` +
+        `verify STRIPE_CREATOR_PRICE_ID / STRIPE_PRO_PRICE_ID env vars`
+    );
+  } else {
+    newTier = tier;
+  }
 
   const { error } = await getAdminClient()
     .from("creators")

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -37,10 +37,21 @@ export const stripe = new Proxy({} as Stripe, {
  * Required env vars:
  *   STRIPE_CREATOR_PRICE_ID   – Price ID for Meridian Creator ($19/mo)
  *   STRIPE_PRO_PRICE_ID       – Price ID for Meridian Pro ($49/mo)
+ *
+ * Throws if either env var is absent — a missing mapping would cause active
+ * subscribers to be silently treated as free-tier users.
+ *
+ * Returns null when the priceId is set but doesn't match a known tier
+ * (e.g. a legacy or test price); callers must handle null explicitly.
  */
 export function tierFromPriceId(
   priceId: string
 ): "creator" | "pro" | null {
+  if (!process.env.STRIPE_CREATOR_PRICE_ID || !process.env.STRIPE_PRO_PRICE_ID) {
+    throw new Error(
+      "STRIPE_CREATOR_PRICE_ID and STRIPE_PRO_PRICE_ID environment variables must both be set"
+    );
+  }
   if (priceId === process.env.STRIPE_CREATOR_PRICE_ID) return "creator";
   if (priceId === process.env.STRIPE_PRO_PRICE_ID) return "pro";
   return null;


### PR DESCRIPTION
## Summary
This PR improves error handling in Stripe webhook processing to catch configuration errors early rather than silently downgrading users to free tier when price IDs are misconfigured.

## Key Changes

- **Enhanced `tierFromPriceId()` validation**: Added explicit checks to ensure both `STRIPE_CREATOR_PRICE_ID` and `STRIPE_PRO_PRICE_ID` environment variables are set at runtime. Throws an error if either is missing, preventing silent failures.

- **Improved `handleCheckoutSessionCompleted()` error handling**: Separated the status check from the tier validation. Now throws a descriptive error when a new subscription has an unrecognized price ID, including the actual price ID and guidance on which env vars to verify.

- **Refactored `handleSubscriptionUpdated()` logic**: Replaced the ternary operator with explicit conditional branches to clearly distinguish three cases:
  - Inactive subscription (cancelled, past_due, etc.) → downgrade to free
  - Active subscription with unrecognized price ID → throw error (configuration issue)
  - Active subscription with recognized price ID → apply the tier

- **Updated documentation**: Added JSDoc comments explaining that the function throws on missing env vars and returns null for unrecognized price IDs, making the contract explicit for callers.

## Implementation Details

The changes ensure that configuration errors (missing or incorrect env vars) are surfaced as exceptions rather than silently treating active subscribers as free-tier users. This prevents data inconsistency and makes debugging easier when Stripe webhooks fail.

https://claude.ai/code/session_01JUJAAqqhFFY3GNWz2CVVRs