### PR TITLE
Add Google Analytics tracking to root layout

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -35,6 +35,20 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
+      <head>
+        {/* Google tag (gtag.js) */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-QHS55ZE82D"></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-QHS55ZE82D');
+            `,
+          }}
+        />
+      </head>
       <body>
         <PostHogProvider>
           {/* Fires $pageview on every client-side navigation */}


### PR DESCRIPTION
## Summary
This PR adds Google Analytics (gtag.js) tracking to the application by integrating the Google tag manager script into the root layout's head section.

## Key Changes
- Added Google Analytics script tag with ID `G-QHS55ZE82D` to the `<head>` of the root layout
- Initialized the Google Analytics data layer and configuration using an inline script
- This enables page view tracking and analytics collection across the entire application

## Implementation Details
- The Google tag manager script is loaded asynchronously to avoid blocking page rendering
- The gtag configuration is initialized with `dangerouslySetInnerHTML` to inject the required JavaScript initialization code
- The tracking is set up at the root layout level, ensuring it applies to all pages in the application

https://claude.ai/code/session_01Narcc96BYGDWXwAYmu9vUf