### PR TITLE
Add fly-worker service for YouTube audio extraction via yt-dlp

### DIFF
--- a/apps/fly-worker/Dockerfile
+++ b/apps/fly-worker/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-slim AS base
+
+# Install yt-dlp and ffmpeg
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 \
+      ffmpeg \
+      curl \
+    && curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
+         -o /usr/local/bin/yt-dlp \
+    && chmod +x /usr/local/bin/yt-dlp \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Build stage ────────────────────────────────────────────────────────────────
+FROM base AS builder
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+# ── Runtime stage ──────────────────────────────────────────────────────────────
+FROM base AS runner
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY package.json ./
+
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "dist/index.js"]

--- a/apps/fly-worker/fly.toml
+++ b/apps/fly-worker/fly.toml
@@ -1,0 +1,20 @@
+app = "meridian-fly-worker"
+primary_region = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 10
+    soft_limit = 5
+
+[[vm]]
+  size = "performance-2x"
+  memory = "4gb"

--- a/apps/fly-worker/package.json
+++ b/apps/fly-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@meridian/fly-worker",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/apps/fly-worker/src/cookies.ts
+++ b/apps/fly-worker/src/cookies.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const NETSCAPE_HEADER = "# Netscape HTTP Cookie File";
+const COOKIES_PATH = path.join(os.tmpdir(), "yt_dlp_cookies.txt");
+
+interface JsonCookie {
+  domain: string;
+  name: string;
+  value: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  expirationDate?: number;
+  session?: boolean;
+}
+
+/**
+ * Converts a JSON cookie array (Chrome DevTools / browser-extension export)
+ * into the 7-field tab-separated Netscape format that yt-dlp expects:
+ *
+ *   domain  subdomain_flag  path  secure  expiry  name  value
+ */
+function jsonCookiesToNetscape(cookies: JsonCookie[]): string {
+  const lines = [NETSCAPE_HEADER];
+  for (const c of cookies) {
+    const domain = c.domain.startsWith(".") ? c.domain : `.${c.domain}`;
+    const includeSubdomains = "TRUE";
+    const cookiePath = c.path ?? "/";
+    const secure = c.secure ? "TRUE" : "FALSE";
+    const expiry = c.session ? "0" : String(Math.round(c.expirationDate ?? 0));
+    lines.push(
+      [domain, includeSubdomains, cookiePath, secure, expiry, c.name, c.value].join("\t")
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Decodes YT_DLP_COOKIES_B64 from the environment and writes a valid
+ * Netscape-format cookie file to a temp path, returning that path.
+ *
+ * Supports two source formats:
+ *   - Netscape text (what yt-dlp and browser "cookies.txt" exports produce)
+ *   - JSON array   (Chrome DevTools / "EditThisCookie" JSON export)
+ *
+ * In both cases a proper "# Netscape HTTP Cookie File" header is guaranteed.
+ *
+ * Returns null when the env var is absent.
+ * Throws when the value is present but cannot be decoded or formatted.
+ */
+export function writeCookiesFile(): string | null {
+  const cookiesB64 = process.env.YT_DLP_COOKIES_B64;
+  if (!cookiesB64) return null;
+
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cookiesB64.trim(), "base64").toString("utf-8").trim();
+  } catch (err) {
+    throw new Error(`YT_DLP_COOKIES_B64: base64 decode failed — ${err}`);
+  }
+
+  if (!decoded) {
+    throw new Error("YT_DLP_COOKIES_B64: decoded to empty string");
+  }
+
+  let content: string;
+
+  // Try JSON array format first (Chrome DevTools / browser extension export)
+  if (decoded.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decoded);
+    } catch (err) {
+      throw new Error(`YT_DLP_COOKIES_B64: looks like JSON but failed to parse — ${err}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("YT_DLP_COOKIES_B64: JSON value is not an array of cookies");
+    }
+    content = jsonCookiesToNetscape(parsed as JsonCookie[]);
+  } else {
+    // Assume Netscape text format; add the required header if it was stripped
+    content = decoded.startsWith(NETSCAPE_HEADER)
+      ? decoded + "\n"
+      : `${NETSCAPE_HEADER}\n${decoded}\n`;
+  }
+
+  fs.writeFileSync(COOKIES_PATH, content, "utf-8");
+  return COOKIES_PATH;
+}

--- a/apps/fly-worker/src/index.ts
+++ b/apps/fly-worker/src/index.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import http from "node:http";
+import { downloadYouTubeAudio } from "./ytdlp.js";
+
+const PORT = Number(process.env.PORT ?? 8080);
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  // POST /audio  body: { videoId: string }
+  if (req.method === "POST" && url.pathname === "/audio") {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", async () => {
+      let videoId: string;
+      try {
+        ({ videoId } = JSON.parse(body) as { videoId: string });
+        if (!videoId || typeof videoId !== "string") throw new Error("missing videoId");
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Request body must be JSON { videoId: string }" }));
+        return;
+      }
+
+      // Sanitize: only allow valid YouTube video IDs (11 alphanumeric chars + - _)
+      if (!/^[A-Za-z0-9_-]{11}$/.test(videoId)) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid YouTube video ID" }));
+        return;
+      }
+
+      let result: Awaited<ReturnType<typeof downloadYouTubeAudio>> | null = null;
+      try {
+        result = await downloadYouTubeAudio(videoId);
+        const stat = fs.statSync(result.audioPath);
+        res.writeHead(200, {
+          "Content-Type": "audio/mp4",
+          "Content-Length": String(stat.size),
+          "X-Video-Id": videoId,
+        });
+        fs.createReadStream(result.audioPath).pipe(res);
+        res.on("finish", () => result?.cleanup());
+      } catch (err) {
+        result?.cleanup();
+        console.error(`[server] /audio failed for ${videoId}:`, err);
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: String(err) }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
+});
+
+server.listen(PORT, () => {
+  console.log(`[fly-worker] listening on port ${PORT}`);
+});

--- a/apps/fly-worker/src/ytdlp.ts
+++ b/apps/fly-worker/src/ytdlp.ts
@@ -1,0 +1,85 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeCookiesFile } from "./cookies.js";
+
+export interface YtDlpResult {
+  audioPath: string;
+  cleanup: () => void;
+}
+
+/**
+ * Downloads the audio track of a YouTube video using yt-dlp.
+ *
+ * Cookie file is written from YT_DLP_COOKIES_B64 if present (required for
+ * age-restricted videos or channels that block anonymous downloads).
+ *
+ * Resolves with the path to the downloaded audio file.
+ * Rejects with an error containing the yt-dlp stderr tail on failure.
+ */
+export async function downloadYouTubeAudio(videoId: string): Promise<YtDlpResult> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "yt-audio-"));
+  const outputTemplate = path.join(tmpDir, "audio.%(ext)s");
+
+  const args = [
+    `https://www.youtube.com/watch?v=${videoId}`,
+    "--format", "bestaudio[ext=m4a]/bestaudio/best",
+    "--extract-audio",
+    "--audio-format", "mp4",
+    "--output", outputTemplate,
+    "--no-playlist",
+    "--quiet",
+    "--no-warnings",
+  ];
+
+  // Write cookies file from env var; pass it to yt-dlp when present
+  let cookiesPath: string | null = null;
+  try {
+    cookiesPath = writeCookiesFile();
+  } catch (err) {
+    console.warn(`[ytdlp] Cookie setup failed, continuing without cookies: ${err}`);
+  }
+  if (cookiesPath) {
+    args.push("--cookies", cookiesPath);
+  }
+
+  const stderrLines: string[] = [];
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn("yt-dlp", args, { stdio: ["ignore", "pipe", "pipe"] });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      const lines = chunk.toString().split("\n").filter(Boolean);
+      stderrLines.push(...lines);
+    });
+
+    proc.on("close", (rc) => {
+      if (rc === 0) {
+        resolve();
+      } else {
+        const tail = stderrLines.slice(-10).join("\n");
+        const err = new Error(
+          `yt-dlp failed rc=${rc} youtube_video_id=${videoId} stderr_tail="${tail}"`
+        );
+        console.error(err.message);
+        reject(err);
+      }
+    });
+
+    proc.on("error", (err) => {
+      reject(new Error(`yt-dlp spawn error: ${err.message}`));
+    });
+  });
+
+  const files = fs.readdirSync(tmpDir);
+  const audioFile = files.find((f) => f.startsWith("audio."));
+  if (!audioFile) {
+    throw new Error(`yt-dlp completed but no audio file found in ${tmpDir}`);
+  }
+
+  return {
+    audioPath: path.join(tmpDir, audioFile),
+    cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+  };
+}

--- a/apps/fly-worker/tsconfig.json
+++ b/apps/fly-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/inngest/src/functions/repurpose-transcript-extraction.ts
+++ b/packages/inngest/src/functions/repurpose-transcript-extraction.ts
@@ -275,9 +275,41 @@ export const extractRepurposeTranscript = inngest.createFunction(
     if (!transcript) {
       transcript = await step.run("whisper-fallback", async () => {
         const mediaUrls: string[] = contentItem.media_urls ?? [];
-        const audioUrl = mediaUrls[0] ?? null;
+        const directAudioUrl = mediaUrls[0] ?? null;
 
-        if (!audioUrl) {
+        let audioRes: Response | null = null;
+
+        if (directAudioUrl) {
+          // Non-YouTube or YouTube with a known direct audio URL
+          audioRes = await fetch(directAudioUrl);
+          if (!audioRes.ok) {
+            console.warn(
+              `[transcript] Audio fetch failed (${audioRes.status}) for ${directAudioUrl}`
+            );
+            return null;
+          }
+        } else if (contentItem.platform === "youtube" && contentItem.external_id) {
+          // YouTube without a direct URL: download via fly-worker (yt-dlp)
+          const workerUrl = process.env.FLY_WORKER_URL;
+          if (!workerUrl) {
+            console.info(
+              `[transcript] FLY_WORKER_URL not set; skipping yt-dlp fallback for content_item ${contentItem.id}`
+            );
+            return null;
+          }
+          const endpoint = `${workerUrl.replace(/\/$/, "")}/audio`;
+          audioRes = await fetch(endpoint, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ videoId: contentItem.external_id }),
+          });
+          if (!audioRes.ok) {
+            console.warn(
+              `[transcript] fly-worker audio fetch failed (${audioRes.status}) for video ${contentItem.external_id}`
+            );
+            return null;
+          }
+        } else {
           console.info(
             `[transcript] No media_url available for Whisper fallback on content_item ${contentItem.id}`
           );
@@ -285,17 +317,9 @@ export const extractRepurposeTranscript = inngest.createFunction(
         }
 
         // Fetch the audio file and pass it to the Whisper API as a File object
-        const audioRes = await fetch(audioUrl);
-        if (!audioRes.ok) {
-          console.warn(
-            `[transcript] Audio fetch failed (${audioRes.status}) for ${audioUrl}`
-          );
-          return null;
-        }
-
         const audioBuffer = await audioRes.arrayBuffer();
-        // Infer a reasonable filename/MIME from the URL; Whisper is lenient
-        const ext = audioUrl.split("?")[0].split(".").pop()?.toLowerCase() ?? "mp4";
+        const sourceUrl = directAudioUrl ?? `youtube:${contentItem.external_id}`;
+        const ext = sourceUrl.split("?")[0].split(".").pop()?.toLowerCase() ?? "mp4";
         const audioFile = new File([audioBuffer], `audio.${ext}`, {
           type: ext === "mp3" ? "audio/mpeg" : "audio/mp4",
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  apps/fly-worker:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.0.0
+        version: 2.97.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22
+        version: 22.19.11
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   apps/mobile:
     dependencies:
       '@meridian/api':
@@ -68,7 +84,7 @@ importers:
         version: 14.0.2(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3)))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))
       nativewind:
         specifier: ^4.1.23
-        version: 4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(yaml@2.8.3))
+        version: 4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: 19.0.3
         version: 19.0.3
@@ -89,7 +105,7 @@ importers:
         version: 4.11.1(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(yaml@2.8.3)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -250,10 +266,10 @@ importers:
         version: 0.73.0(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3)
       nativewind:
         specifier: ^4.1.23
-        version: 4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(yaml@2.8.3))
+        version: 4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(yaml@2.8.3)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -824,9 +840,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -836,9 +864,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -848,9 +888,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -860,9 +912,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -872,9 +936,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -884,9 +960,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -896,9 +984,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -908,9 +1008,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -920,11 +1032,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -932,9 +1068,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -944,15 +1098,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -4080,6 +4252,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -6598,6 +6775,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.8.10:
     resolution: {integrity: sha512-A03fXh+B7S8mL3PbdhTd+0UsaGrhfyPkODvzBDpKRY7bbeac4MDFpJ7I+Slf2oSkCEeSvHKR7Z4U71uKRUfX7g==}
     cpu: [x64]
@@ -7693,70 +7875,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@1.21.7))':
@@ -8458,7 +8718,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -10580,7 +10840,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10613,6 +10873,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/oracledb@6.5.2':
     dependencies:
@@ -10663,7 +10924,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -11325,7 +11586,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11334,7 +11595,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11775,6 +12036,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -12928,7 +13218,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12980,7 +13270,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -13411,12 +13701,12 @@ snapshots:
 
   napi-postinstall@0.3.4: {}
 
-  nativewind@4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(yaml@2.8.3)):
+  nativewind@4.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       comment-json: 4.6.2
       debug: 4.4.3
-      react-native-css-interop: 0.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(yaml@2.8.3))
-      tailwindcss: 3.4.19(yaml@2.8.3)
+      react-native-css-interop: 0.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - react
       - react-native
@@ -13716,12 +14006,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.4.49
+      tsx: 4.21.0
       yaml: 2.8.3
 
   postcss-nested@6.2.0(postcss@8.4.49):
@@ -13857,7 +14148,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.11
       long: 5.3.2
 
   protobufjs@8.0.1:
@@ -13932,7 +14223,7 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-css-interop@0.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(yaml@2.8.3)):
+  react-native-css-interop@0.2.2(react-native-reanimated@4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native-safe-area-context@5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
@@ -13943,7 +14234,7 @@ snapshots:
       react-native: 0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3)
       react-native-reanimated: 4.2.2(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)
       semver: 7.7.4
-      tailwindcss: 3.4.19(yaml@2.8.3)
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       react-native-safe-area-context: 5.4.0(react-native@0.79.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.0.3))(react@19.0.3)
     transitivePeerDependencies:
@@ -14631,7 +14922,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19(yaml@2.8.3):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -14650,7 +14941,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.1.0(postcss@8.4.49)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -14745,6 +15036,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.10:
     optional: true
 
@@ -14830,7 +15128,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@6.23.0: {}
 


### PR DESCRIPTION
## Summary
This PR introduces a new `fly-worker` service that provides YouTube audio extraction capabilities via yt-dlp, and integrates it into the transcript extraction pipeline as a fallback for videos without direct audio URLs.

## Key Changes

- **New fly-worker service** (`apps/fly-worker/`)
  - HTTP server with `/audio` endpoint that accepts a YouTube video ID and returns the extracted audio
  - `/health` endpoint for service monitoring
  - Supports cookie-based authentication via `YT_DLP_COOKIES_B64` environment variable for age-restricted or region-locked content
  - Includes Docker configuration and Fly.io deployment setup

- **Cookie handling** (`apps/fly-worker/src/cookies.ts`)
  - Converts base64-encoded cookies from environment variable into Netscape format
  - Supports both JSON (Chrome DevTools/browser extension) and Netscape text formats
  - Automatically adds required Netscape header if missing

- **yt-dlp integration** (`apps/fly-worker/src/ytdlp.ts`)
  - Spawns yt-dlp process to download best available audio in MP4 format
  - Handles cookie file setup and passes it to yt-dlp when available
  - Returns audio file path with cleanup callback for temporary directory management
  - Captures and reports stderr on failure

- **Transcript extraction enhancement** (`packages/inngest/src/functions/repurpose-transcript-extraction.ts`)
  - Modified Whisper fallback to use fly-worker for YouTube videos without direct audio URLs
  - Falls back to fly-worker when `FLY_WORKER_URL` is configured and content is from YouTube platform
  - Maintains existing behavior for direct audio URLs and non-YouTube content

## Implementation Details

- The fly-worker validates YouTube video IDs (11 alphanumeric characters + `-` and `_`) to prevent injection attacks
- Audio extraction uses `bestaudio[ext=m4a]/bestaudio/best` format preference with MP4 output
- Temporary directories are created per request and cleaned up after streaming completes
- Cookie setup failures are logged as warnings but don't block the download attempt
- The service is configured for Fly.io with auto-scaling (0-N machines) and request-based concurrency limits

https://claude.ai/code/session_01MtZZQ9sAocaMxo5iSFtmuM